### PR TITLE
run on push too

### DIFF
--- a/.github/workflows/commits.yaml
+++ b/.github/workflows/commits.yaml
@@ -1,5 +1,5 @@
-name: Pull Request
-on: [pull_request]
+name: Commits
+on: [pull_request, push]
 jobs:
   Checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What It Does

Run CI on push too so main gets coverage reports.

## Related Issues

<!-- Please add links to any related issues here. -->
