### PR TITLE
avoid duplicate jobs on prs

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -1,5 +1,9 @@
 name: Commit
-on: [pull_request, push]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
 jobs:
   Checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What It Does

Avoids creating duplicate CI jobs on PRs by filtering "push" workflow executions by branch.

## Related Issues

<!-- Please add links to any related issues here. -->
