### PR TITLE
Add a basic modal implementation

### DIFF
--- a/examples/modal.rs
+++ b/examples/modal.rs
@@ -1,0 +1,76 @@
+use iocraft::prelude::*;
+
+#[component]
+fn Popup(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+    let (width, height) = hooks.use_terminal_size();
+    let mut system = hooks.use_context_mut::<SystemContext>();
+    let mut should_popup = hooks.use_state(|| false);
+    let mut should_exit = hooks.use_state(|| false);
+
+    hooks.use_terminal_events(move |event| match event {
+        TerminalEvent::Key(KeyEvent { code, kind, .. }) if kind != KeyEventKind::Release => {
+            match code {
+                KeyCode::Char('x') => should_popup.set(false),
+                KeyCode::Char('q') => should_exit.set(true),
+                KeyCode::Char('s') => should_popup.set(true),
+                _ => {}
+            }
+        }
+        _ => {}
+    });
+
+    if should_exit.get() {
+        system.exit();
+    }
+
+    element! {
+        Box(
+            width: width - 1,
+            height: height,
+            flex_direction: FlexDirection::Column,
+            border_style: BorderStyle::Round,
+            border_color: Color::Magenta,
+            gap: 1
+        ) {
+            Box(
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                margin: 2,
+            ) {
+                Box(
+                    align_items: AlignItems::Center,
+                ) {
+                    Text(content: "Press 's' to display a popup and 'x' to exit!")
+                }
+                Box(
+                    align_items: AlignItems::Center,
+                ) {
+                    Text(content: "Press 'q' to exit!")
+                }
+                Box(
+                    width: 78
+                ) {
+                    Text(
+                        align: TextAlign::Center,
+                        wrap: TextWrap::Wrap,
+                        content: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+                    )
+                }
+                Modal(is_open: should_popup.get()) {
+                    Box(
+                        align_items: AlignItems::Center,
+                        border_style: BorderStyle::Round,
+                        border_color: Color::Green,
+                        position: Position::Absolute
+                    ) {
+                        Text(content: "안영하세요!")
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    smol::block_on(element!(Popup).fullscreen()).unwrap();
+}

--- a/packages/iocraft/src/components/mod.rs
+++ b/packages/iocraft/src/components/mod.rs
@@ -4,6 +4,9 @@ pub use r#box::*;
 mod context_provider;
 pub use context_provider::*;
 
+mod modal;
+pub use modal::*;
+
 mod text;
 pub use text::*;
 

--- a/packages/iocraft/src/components/modal.rs
+++ b/packages/iocraft/src/components/modal.rs
@@ -1,0 +1,53 @@
+use crate::{AnyElement, Component};
+use iocraft_macros::{with_layout_style_props, Props};
+
+/// Defines properties for a `Modal`.
+#[non_exhaustive]
+#[with_layout_style_props]
+#[derive(Default, Props)]
+pub struct ModalProps<'a> {
+    /// The elements to render inside of the `Modal`.
+    pub children: Vec<AnyElement<'a>>,
+
+    /// Whether to render the `Modal`.
+    pub is_open: bool,
+    // TODO(nyanzebra): after open and after close events?
+}
+
+/// `Modal` is a component that renders a 'popup'.
+#[derive(Default)]
+pub struct Modal {
+    /// Whether to render the `Modal`.
+    is_open: bool,
+    // TODO(nyanzebra): after open and after close events?
+}
+
+impl Component for Modal {
+    type Props<'a> = ModalProps<'a>;
+
+    fn new(_props: &Self::Props<'_>) -> Self {
+        Self::default()
+    }
+
+    fn update(
+        &mut self,
+        props: &mut Self::Props<'_>,
+        _hooks: crate::Hooks,
+        updater: &mut crate::ComponentUpdater,
+    ) {
+        updater.set_transparent_layout(true);
+        self.is_open = props.is_open;
+        let mut style: taffy::style::Style = props.layout_style().into();
+        if self.is_open {
+            style.display = taffy::Display::Flex;
+            updater.update_children(props.children.iter_mut(), None);
+        } else {
+            let mut empty: Vec<AnyElement<'_>> = vec![];
+            updater.update_children(empty.iter_mut(), None);
+            style.display = taffy::Display::None;
+        }
+        updater.set_layout_style(style);
+    }
+
+    fn draw(&mut self, _drawer: &mut crate::ComponentDrawer<'_>) {}
+}


### PR DESCRIPTION
## What It Does

This adds a basic modal implementation, below are images that show what the example looks like. Will update examples with a gif after getting initial feedback.

<img width="733" alt="image" src="https://github.com/user-attachments/assets/2d7f6eb3-b2f0-4613-bbbc-8f8d721ac92a">

<img width="733" alt="image" src="https://github.com/user-attachments/assets/addd7d9d-6766-4717-8179-848a2bfb0984">

What is not included:
* callbacks for when modal opens/closes
* examples with forms (common usage?)
* should maybe consider making a more fundamental component that modal can be built off of, for example, the same logic might help with other types of pop-ups?

## Related Issues

<!-- Please add links to any related issues here. -->
