### PR TITLE
feat: enable "std" feature for taffy

### DIFF
--- a/packages/iocraft/Cargo.toml
+++ b/packages/iocraft/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ccbrown/iocraft"
 [dependencies]
 crossterm = { version = "0.28.1", features = ["event-stream"] }
 futures = "0.3.30"
-taffy = { version = "0.5.2", default-features = false, features = ["flexbox", "taffy_tree"] }
+taffy = { version = "0.5.2", default-features = false, features = ["std", "flexbox", "taffy_tree"] }
 iocraft-macros = { version = "0.1.7", path = "../iocraft-macros" }
 bitflags = "2.6.0"
 unicode-width = "0.1.13"


### PR DESCRIPTION
## What It Does

I was trying to print out a table but my program would panic with the error `called `Result::unwrap()` on an `Err` value: CapacityError: insufficient capacity`. This was due to that if `taffy` does not have its `alloc` or `std` features enabled then it uses arrays with a maximum capacity, which limits e.g. in my case the number of children a node can have. It didn't seem to me that the `std` feature was intentionally excluded so I added it in.