### PR TITLE
feat: make async functions send+sync

### DIFF
--- a/packages/iocraft-macros/src/lib.rs
+++ b/packages/iocraft-macros/src/lib.rs
@@ -531,12 +531,12 @@ impl ToTokens for ParsedComponent {
 /// ```
 /// # use iocraft::prelude::*;
 /// #[derive(Default, Props)]
-/// struct MyGenericComponentProps<T> {
+/// struct MyGenericComponentProps<T: Send + Sync> {
 ///     items: Vec<T>,
 /// }
 ///
 /// #[component]
-/// fn MyGenericComponent<T: 'static>(
+/// fn MyGenericComponent<T: Send + Sync + 'static>(
 ///     _props: &MyGenericComponentProps<T>,
 /// ) -> impl Into<AnyElement<'static>> {
 ///     element!(Box)

--- a/packages/iocraft-macros/tests/component.rs
+++ b/packages/iocraft-macros/tests/component.rs
@@ -29,20 +29,20 @@ fn MyComponentWithHooksRef(_hooks: &mut Hooks) -> impl Into<AnyElement<'static>>
 }
 
 #[derive(Props)]
-struct MyGenericProps<T, const U: usize> {
+struct MyGenericProps<T: Send + Sync, const U: usize> {
     foo: [T; U],
 }
 
 #[component]
-fn MyComponentWithGenericProps<T: 'static, const U: usize>(
+fn MyComponentWithGenericProps<T: Send + Sync + 'static, const U: usize>(
     _props: &mut MyGenericProps<T, U>,
 ) -> impl Into<AnyElement<'static>> {
     element!(Box)
 }
 
-fn check_component_traits<T: Sync + Send>() {}
+fn check_component_traits<T: Send + Sync>() {}
 
-fn check_component_traits_with_generic<T: 'static, const U: usize>() {
+fn check_component_traits_with_generic<T: Send + Sync + 'static, const U: usize>() {
     check_component_traits::<MyComponentWithGenericProps<T, U>>();
 }
 
@@ -51,7 +51,7 @@ fn MyComponentWithGenericPropsWhereClause<T, const U: usize>(
     _props: &mut MyGenericProps<T, U>,
 ) -> impl Into<AnyElement<'static>>
 where
-    T: 'static,
+    T: Send + Sync + 'static,
 {
     element!(Box)
 }

--- a/packages/iocraft-macros/tests/element.rs
+++ b/packages/iocraft-macros/tests/element.rs
@@ -35,16 +35,16 @@ impl Component for MyContainer {
     }
 }
 
-struct MyGenericComponent<T> {
-    _marker: std::marker::PhantomData<*const T>,
+struct MyGenericComponent<T: Sync + 'static> {
+    _marker: std::marker::PhantomData<&'static T>,
 }
 
 #[derive(Default, Props)]
-struct MyGenericComponentProps<T> {
+struct MyGenericComponentProps<T: Send + Sync> {
     items: Vec<T>,
 }
 
-impl<T: 'static> Component for MyGenericComponent<T> {
+impl<T: Send + Sync + 'static> Component for MyGenericComponent<T> {
     type Props<'a> = MyGenericComponentProps<T>;
 
     fn new(_props: &Self::Props<'_>) -> Self {

--- a/packages/iocraft-macros/tests/props.rs
+++ b/packages/iocraft-macros/tests/props.rs
@@ -25,11 +25,11 @@ struct StructWithLifetimeAndConsts<'lt, const N: usize, const M: usize> {
 }
 
 #[derive(Props)]
-struct StructWithTypeGeneric<T> {
+struct StructWithTypeGeneric<T: Send + Sync> {
     foo: T,
 }
 
 #[derive(Props)]
-struct StructWithLifetimeAndTypeGeneric<'lt, T> {
+struct StructWithLifetimeAndTypeGeneric<'lt, T: Sync> {
     foo: &'lt T,
 }

--- a/packages/iocraft-macros/tests/with_layout_style_props.rs
+++ b/packages/iocraft-macros/tests/with_layout_style_props.rs
@@ -15,7 +15,7 @@ struct MyPropsWithLifetime<'lt> {
 
 #[with_layout_style_props]
 #[derive(Default, Props)]
-struct MyPropsWithTypeGeneric<T> {
+struct MyPropsWithTypeGeneric<T: Send + Sync> {
     foo: Option<T>,
 }
 

--- a/packages/iocraft/src/component.rs
+++ b/packages/iocraft/src/component.rs
@@ -28,7 +28,7 @@ impl<C: Component> ComponentHelper<C> {
 }
 
 #[doc(hidden)]
-pub trait ComponentHelperExt: Any {
+pub trait ComponentHelperExt: Any + Send + Sync {
     fn new_component(&self, props: AnyProps) -> Box<dyn AnyComponent>;
     fn update_component(
         &self,
@@ -70,7 +70,7 @@ impl<C: Component> ComponentHelperExt for ComponentHelper<C> {
 ///
 /// Most users will not need to implement this trait directly. This is only required for new, low
 /// level component type definitions. Instead, the [`component`](macro@crate::component) macro should be used.
-pub trait Component: Any + Unpin {
+pub trait Component: Any + Send + Sync + Unpin {
     /// The type of properties that the component accepts.
     type Props<'a>: Props
     where
@@ -103,7 +103,7 @@ impl<C: Component> ElementType for C {
 }
 
 #[doc(hidden)]
-pub trait AnyComponent: Any + Unpin {
+pub trait AnyComponent: Any + Send + Sync + Unpin {
     fn update(&mut self, props: AnyProps, hooks: Hooks, updater: &mut ComponentUpdater);
     fn draw(&mut self, drawer: &mut ComponentDrawer<'_>);
     fn poll_change(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()>;

--- a/packages/iocraft/src/context.rs
+++ b/packages/iocraft/src/context.rs
@@ -29,31 +29,31 @@ impl SystemContext {
 pub enum Context<'a> {
     /// Provides the context via a mutable reference. Children will be able to get mutable or
     /// immutable references to the context.
-    Mut(&'a mut dyn Any),
+    Mut(&'a mut (dyn Any + Send + Sync)),
     /// Provides the context via an immutable reference. Children will not be able to get a mutable
     /// reference to the context.
-    Ref(&'a dyn Any),
+    Ref(&'a (dyn Any + Send + Sync)),
     /// Provides the context via an owned value. Children will be able to get mutable or immutable
     /// references to the context.
-    Owned(Box<dyn Any>),
+    Owned(Box<(dyn Any + Send + Sync)>),
 }
 
 impl<'a> Context<'a> {
     /// Creates a new context from an owned value. Children will be able to get mutable or
     /// immutable references to the context.
-    pub fn owned<T: Any>(context: T) -> Self {
+    pub fn owned<T: Any + Send + Sync>(context: T) -> Self {
         Context::Owned(Box::new(context))
     }
 
     /// Creates a new context from a mutable reference. Children will be able to get mutable or
     /// immutable references to the context.
-    pub fn from_mut<T: Any>(context: &'a mut T) -> Self {
+    pub fn from_mut<T: Any + Send + Sync>(context: &'a mut T) -> Self {
         Context::Mut(context)
     }
 
     /// Creates a new context from an immutable reference. Children will not be able to get a
     /// mutable reference to the context.
-    pub fn from_ref<T: Any>(context: &'a T) -> Self {
+    pub fn from_ref<T: Any + Send + Sync>(context: &'a T) -> Self {
         Context::Ref(context)
     }
 
@@ -91,7 +91,7 @@ pub struct ContextStack<'a> {
 }
 
 impl<'a> ContextStack<'a> {
-    pub(crate) fn root(root_context: &'a mut dyn Any) -> Self {
+    pub(crate) fn root(root_context: &'a mut (dyn Any + Send + Sync)) -> Self {
         Self {
             contexts: vec![RefCell::new(Context::Mut(root_context))],
         }

--- a/packages/iocraft/src/element.rs
+++ b/packages/iocraft/src/element.rs
@@ -12,7 +12,7 @@ use std::{
     future::Future,
     hash::Hash,
     io::{self, stderr, stdout, IsTerminal, Write},
-    rc::Rc,
+    sync::Arc,
 };
 
 /// Used by the `element!` macro to extend a collection with elements.
@@ -60,12 +60,12 @@ where
 /// Used to identify an element within the scope of its parent. This is used to minimize the number
 /// of times components are destroyed and recreated from render-to-render.
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub struct ElementKey(Rc<Box<dyn AnyHash>>);
+pub struct ElementKey(Arc<Box<dyn AnyHash + Send + Sync>>);
 
 impl ElementKey {
     /// Constructs a new key.
-    pub fn new<K: Debug + Hash + Eq + 'static>(key: K) -> Self {
-        Self(Rc::new(Box::new(key)))
+    pub fn new<K: Debug + Hash + Eq + Send + Sync + 'static>(key: K) -> Self {
+        Self(Arc::new(Box::new(key)))
     }
 }
 

--- a/packages/iocraft/src/handler.rs
+++ b/packages/iocraft/src/handler.rs
@@ -7,7 +7,7 @@ use std::{
 ///
 /// Any function that takes a single argument and returns `()` can be converted into a `Handler`,
 /// and it can be invoked using function call syntax.
-pub struct Handler<'a, T>(bool, Box<dyn FnMut(T) + Send + 'a>);
+pub struct Handler<'a, T>(bool, Box<dyn FnMut(T) + Send + Sync + 'a>);
 
 impl<'a, T> Handler<'a, T> {
     /// Returns `true` if the handler was default-initialized.
@@ -29,7 +29,7 @@ impl<'a, T> Default for Handler<'a, T> {
 
 impl<'a, T, F> From<F> for Handler<'a, T>
 where
-    F: FnMut(T) + Send + 'a,
+    F: FnMut(T) + Send + Sync + 'a,
 {
     fn from(f: F) -> Self {
         Self(true, Box::new(f))
@@ -37,7 +37,7 @@ where
 }
 
 impl<'a, T: 'a> Deref for Handler<'a, T> {
-    type Target = dyn FnMut(T) + Send + 'a;
+    type Target = dyn FnMut(T) + Send + Sync + 'a;
 
     fn deref(&self) -> &Self::Target {
         &self.1

--- a/packages/iocraft/src/hook.rs
+++ b/packages/iocraft/src/hook.rs
@@ -10,7 +10,7 @@ use std::{
 ///
 /// Hooks are created by implementing this trait. All methods have default implementations, so
 /// you only need to implement the ones you care about.
-pub trait Hook: Unpin {
+pub trait Hook: Unpin + Send {
     /// Called to determine if the hook has caused a change which requires its component to be
     /// redrawn.
     fn poll_change(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<()> {

--- a/packages/iocraft/src/hooks/use_async_handler.rs
+++ b/packages/iocraft/src/hooks/use_async_handler.rs
@@ -21,14 +21,14 @@ pub trait UseAsyncHandler: private::Sealed {
     /// resulting future to completion.
     fn use_async_handler<T, Fun, Fut>(&mut self, f: Fun) -> Handler<'static, T>
     where
-        Fun: FnMut(T) -> Fut + Send + 'static,
+        Fun: FnMut(T) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static;
 }
 
 impl UseAsyncHandler for Hooks<'_, '_> {
     fn use_async_handler<T, Fun, Fut>(&mut self, mut f: Fun) -> Handler<'static, T>
     where
-        Fun: FnMut(T) -> Fut + Send + 'static,
+        Fun: FnMut(T) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
         let handler_impl_state = self.use_hook(UseAsyncHandlerImpl::default).state.clone();

--- a/packages/iocraft/src/props.rs
+++ b/packages/iocraft/src/props.rs
@@ -60,7 +60,7 @@ use std::marker::PhantomData;
 /// implemented for a type that is not actually covariant, then the safety of the program is
 /// compromised. You can use the [`#[derive(Props)]`](derive@crate::Props) macro to implement this trait safely. If the
 /// type is not actually covariant, the derive macro will give you an error at compile-time.
-pub unsafe trait Props {}
+pub unsafe trait Props: Send + Sync {}
 
 #[doc(hidden)]
 #[derive(Clone, Copy, iocraft_macros::Props, Default)]
@@ -88,6 +88,12 @@ pub struct AnyProps<'a> {
     drop: Option<Box<dyn DropRaw + 'a>>,
     _marker: PhantomData<&'a mut ()>,
 }
+
+// SAFETY: Safe because `Props` must be `Send` and `Sync`.
+unsafe impl Send for AnyProps<'_> {}
+
+// SAFETY: Safe because `Props` must be `Sync`.
+unsafe impl Sync for AnyProps<'_> {}
 
 impl<'a> AnyProps<'a> {
     pub(crate) fn owned<T: Props + 'a>(props: T) -> Self {

--- a/packages/iocraft/src/render.rs
+++ b/packages/iocraft/src/render.rs
@@ -466,8 +466,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::prelude::*;
-    use futures::stream::StreamExt;
     use macro_rules_attribute::apply;
     use smol_macros::test;
     use std::future::Future;
@@ -528,20 +528,15 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    async fn await_send_future<F: Future<Output = ()> + Send>(f: F) {
-        f.await;
+    async fn await_send_future<F: Future<Output = io::Result<()>> + Send>(f: F) {
+        f.await.unwrap();
     }
 
     // Make sure terminal_render_loop can be sent across threads.
     #[apply(test!)]
     async fn test_terminal_render_loop_send() {
         let (term, _output) = Terminal::mock(MockTerminalConfig::default());
-        await_send_future(async move {
-            terminal_render_loop(element!(MyComponent), term)
-                .await
-                .unwrap();
-        })
-        .await;
+        await_send_future(terminal_render_loop(element!(MyComponent), term)).await;
     }
 
     #[component]

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -111,7 +111,7 @@ impl Stream for TerminalEvents {
     }
 }
 
-trait TerminalImpl: Write {
+trait TerminalImpl: Write + Send {
     fn width(&self) -> Option<u16>;
     fn is_raw_mode_enabled(&self) -> bool;
     fn clear_canvas(&mut self) -> io::Result<()>;


### PR DESCRIPTION
## What It Does

This makes it possible to use iocraft futures where `Send` is required.

The downside is it requires all `Props` implementations and all context to be `Send + Sync`. In reality, what sorts of use-cases would this actually negatively impact?

Relevant: https://github.com/async-graphql/async-graphql/pull/1122

The question is probably whether this should be merged as-is or gated behind a feature flag.

## Related Issues

- Closes #37 