### PR TITLE
fix: eliminate undesired impact of transparent components on layout

### DIFF
--- a/packages/iocraft/src/component.rs
+++ b/packages/iocraft/src/component.rs
@@ -162,7 +162,7 @@ impl InstantiatedComponent {
     pub fn update(
         &mut self,
         context: &mut UpdateContext<'_>,
-        unattached_child_node_ids: Option<&mut Vec<NodeId>>,
+        unattached_child_node_ids: &mut Vec<NodeId>,
         component_context_stack: &mut ContextStack<'_>,
         props: AnyProps,
     ) {

--- a/packages/iocraft/src/components/box.rs
+++ b/packages/iocraft/src/components/box.rs
@@ -346,6 +346,18 @@ mod tests {
     use crate::prelude::*;
     use indoc::indoc;
 
+    #[derive(Default, Props)]
+    pub struct MyTextProps {
+        pub content: String,
+    }
+
+    #[component]
+    pub fn MyText<'a>(props: &MyTextProps) -> impl Into<AnyElement<'a>> {
+        element! {
+            Text(content: &props.content)
+        }
+    }
+
     #[test]
     fn test_box() {
         assert_eq!(element!(Box).to_string(), "");
@@ -588,6 +600,27 @@ mod tests {
             indoc! {"
                 ┌──────────────────┐
                 │foo  bar          │
+                └──────────────────┘
+            "},
+        );
+
+        // regression test for https://github.com/ccbrown/iocraft/issues/52
+        assert_eq!(
+            element! {
+                Box(width: 20, border_style: BorderStyle::Single, row_gap: 1, flex_direction: FlexDirection::Column) {
+                    Text(content: "foo")
+                    MyText(content: "bar")
+                    MyText(content: "baz")
+                }
+            }
+            .to_string(),
+            indoc! {"
+                ┌──────────────────┐
+                │foo               │
+                │                  │
+                │bar               │
+                │                  │
+                │baz               │
                 └──────────────────┘
             "},
         );


### PR DESCRIPTION
## What It Does

Eliminates the impact of transparent components on layout by making them "display: none".

## Related Issues

- Fixes https://github.com/ccbrown/iocraft/issues/52