### PR TITLE
feat!: rename `Box` to `View` to avoid conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use iocraft::prelude::*;
 
 fn main() {
     element! {
-        Box(
+        View(
             border_style: BorderStyle::Round,
             border_color: Color::Blue,
         ) {
@@ -55,7 +55,7 @@ fn main() {
 Your UI is composed primarily via the `element!` macro, which allows you to
 declare your UI elements in a React/SwiftUI-like syntax.
 
-`iocraft` provides a few built-in components, such as `Box`, `Text`, and
+`iocraft` provides a few built-in components, such as `View`, `Text`, and
 `TextInput`, but you can also create your own using the `#[component]` macro.
 
 For example, here's a custom component that uses a hook to display a counter

--- a/examples/borders.rs
+++ b/examples/borders.rs
@@ -2,30 +2,30 @@ use iocraft::prelude::*;
 
 fn main() {
     element! {
-        Box(flex_direction: FlexDirection::Column, padding: 2) {
-            Box {
-                Box(border_style: BorderStyle::Single, margin_right: 2) {
+        View(flex_direction: FlexDirection::Column, padding: 2) {
+            View {
+                View(border_style: BorderStyle::Single, margin_right: 2) {
                     Text(content: "Single")
                 }
-                Box(border_style: BorderStyle::Double, margin_right: 2) {
+                View(border_style: BorderStyle::Double, margin_right: 2) {
                     Text(content: "Double")
                 }
-                Box(border_style: BorderStyle::Round, margin_right: 2) {
+                View(border_style: BorderStyle::Round, margin_right: 2) {
                     Text(content: "Round")
                 }
-                Box(border_style: BorderStyle::Bold) {
+                View(border_style: BorderStyle::Bold) {
                     Text(content: "Bold")
                 }
             }
 
-            Box(margin_top: 1) {
-                Box(border_style: BorderStyle::DoubleLeftRight, margin_right: 2) {
+            View(margin_top: 1) {
+                View(border_style: BorderStyle::DoubleLeftRight, margin_right: 2) {
                     Text(content: "DoubleLeftRight")
                 }
-                Box(border_style: BorderStyle::DoubleTopBottom, margin_right: 2) {
+                View(border_style: BorderStyle::DoubleTopBottom, margin_right: 2) {
                     Text(content: "DoubleTopBottom")
                 }
-                Box(border_style: BorderStyle::Classic) {
+                View(border_style: BorderStyle::Classic) {
                     Text(content: "Classic")
                 }
             }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -105,7 +105,7 @@ struct ScreenProps {
 fn Screen(hooks: Hooks, props: &ScreenProps) -> impl Into<AnyElement<'static>> {
     let theme = hooks.use_context::<Theme>();
     element! {
-        Box(
+        View(
             width: 100pct,
             border_style: BorderStyle::Custom(BorderCharacters {
                 top: '▁',
@@ -114,7 +114,7 @@ fn Screen(hooks: Hooks, props: &ScreenProps) -> impl Into<AnyElement<'static>> {
             border_edges: Edges::Top,
             border_color: theme.screen_trim_color(),
         ) {
-            Box(
+            View(
                 width: 100pct,
                 background_color: theme.screen_color(),
                 padding: 1,
@@ -143,7 +143,7 @@ fn CalculatorButton(props: &mut CalculatorButtonProps) -> impl Into<AnyElement<'
 
     element! {
         Button(handler: props.on_click.take()) {
-            Box(
+            View(
                 border_style: BorderStyle::Custom(BorderCharacters {
                     top: '▁',
                     ..Default::default()
@@ -154,7 +154,7 @@ fn CalculatorButton(props: &mut CalculatorButtonProps) -> impl Into<AnyElement<'
                 margin_left: 1,
                 margin_right: 1,
             ) {
-                Box(
+                View(
                     background_color: style.color,
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
@@ -289,44 +289,44 @@ fn Calculator(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     });
 
     element! {
-        Box(
+        View(
             width: 100pct,
             height: 100pct,
             flex_direction: FlexDirection::Column,
             padding_left: 1,
             padding_right: 1,
         ) {
-            Box(
+            View(
                 padding_left: 1,
                 padding_right: 1,
             ) {
                 Screen(content: expr.to_string())
             }
-            Box(width: 100pct) {
+            View(width: 100pct) {
                 CalculatorButton(label: "←", style: fn_button_style, on_click: move |_| handle_backspace())
                 CalculatorButton(label: "±", style: fn_button_style, on_click: move |_| handle_plus_minus())
                 CalculatorButton(label: "%", style: fn_button_style, on_click: move |_| handle_percent())
                 CalculatorButton(label: "÷", style: operator_button_style, on_click: move |_| handle_operator('÷'))
             }
-            Box(width: 100pct) {
+            View(width: 100pct) {
                 CalculatorButton(label: "7", style: numpad_button_style, on_click: move |_| handle_number(7))
                 CalculatorButton(label: "8", style: numpad_button_style, on_click: move |_| handle_number(8))
                 CalculatorButton(label: "9", style: numpad_button_style, on_click: move |_| handle_number(9))
                 CalculatorButton(label: "×", style: operator_button_style, on_click: move |_| handle_operator('×'))
             }
-            Box(width: 100pct) {
+            View(width: 100pct) {
                 CalculatorButton(label: "4", style: numpad_button_style, on_click: move |_| handle_number(4))
                 CalculatorButton(label: "5", style: numpad_button_style, on_click: move |_| handle_number(5))
                 CalculatorButton(label: "6", style: numpad_button_style, on_click: move |_| handle_number(6))
                 CalculatorButton(label: "-", style: operator_button_style, on_click: move |_| handle_operator('-'))
             }
-            Box(width: 100pct) {
+            View(width: 100pct) {
                 CalculatorButton(label: "1", style: numpad_button_style, on_click: move |_| handle_number(1))
                 CalculatorButton(label: "2", style: numpad_button_style, on_click: move |_| handle_number(2))
                 CalculatorButton(label: "3", style: numpad_button_style, on_click: move |_| handle_number(3))
                 CalculatorButton(label: "+", style: operator_button_style, on_click: move |_| handle_operator('+'))
             }
-            Box(width: 100pct) {
+            View(width: 100pct) {
                 CalculatorButton(label: "C", style: theme.clear_button_style(), on_click: move |_| handle_clear())
                 CalculatorButton(label: "0", style: numpad_button_style, on_click: move |_| handle_number(0))
                 CalculatorButton(label: ".", style: numpad_button_style, on_click: move |_| handle_decimal())
@@ -361,7 +361,7 @@ fn App(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     }
 
     element! {
-        Box(
+        View(
             // subtract one in case there's a scrollbar
             width: width - 1,
             height: height,
@@ -369,10 +369,10 @@ fn App(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             flex_direction: FlexDirection::Column,
             gap: 1,
         ) {
-            Box(
+            View(
                 flex_grow: 1.0,
             ) {
-                Box(
+                View(
                     max_width: 120,
                     max_height: 40,
                     flex_grow: 1.0,
@@ -382,7 +382,7 @@ fn App(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     }
                 }
             }
-            Box(
+            View(
                 height: 1,
                 background_color: theme.get().footer_background_color(),
                 padding_left: 1,

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -7,7 +7,7 @@ fn MyContextConsumer(hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let number = hooks.use_context::<NumberOfTheDay>();
 
     element! {
-        Box(border_style: BorderStyle::Round, border_color: Color::Cyan) {
+        View(border_style: BorderStyle::Round, border_color: Color::Cyan) {
             Text(content: "The number of the day is... ")
             Text(color: Color::Green, weight: Weight::Bold, content: number.0.to_string())
             Text(content: "!")

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -14,16 +14,16 @@ fn FormField(props: &FormFieldProps) -> impl Into<AnyElement<'static>> {
     };
 
     element! {
-        Box(
+        View(
             border_style: if props.has_focus { BorderStyle::Round } else { BorderStyle::None },
             border_color: Color::Blue,
             padding_left: if props.has_focus { 0 } else { 1 },
             padding_right: if props.has_focus { 0 } else { 1 },
         ) {
-            Box(width: 15) {
+            View(width: 15) {
                 Text(content: format!("{}: ", props.label))
             }
-            Box(
+            View(
                 background_color: Color::DarkGrey,
                 width: 30,
             ) {
@@ -71,15 +71,15 @@ fn Form<'a>(props: &mut FormProps<'a>, mut hooks: Hooks) -> impl Into<AnyElement
             **last_name_out = last_name.to_string();
         }
         system.exit();
-        element!(Box)
+        element!(View)
     } else {
         element! {
-            Box(
+            View(
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 margin: 2,
             ) {
-                Box(
+                View(
                     padding_bottom: if focus == 0 { 1 } else { 2 },
                     flex_direction: FlexDirection::Column,
                     align_items: AlignItems::Center,

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -33,7 +33,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     }
 
     element! {
-        Box(
+        View(
             // subtract one in case there's a scrollbar
             width: width - 1,
             height,
@@ -44,7 +44,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
         ) {
-            Box(
+            View(
                 border_style: BorderStyle::Round,
                 border_color: Color::Blue,
                 margin_bottom: 2,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,7 +2,7 @@ use iocraft::prelude::*;
 
 fn main() {
     element! {
-        Box(
+        View(
             border_style: BorderStyle::Round,
             border_color: Color::Blue,
         ) {

--- a/examples/overlap.rs
+++ b/examples/overlap.rs
@@ -11,20 +11,20 @@ at conubia venenatis.";
 
 fn main() {
     element! {
-        Box(
+        View(
             border_style: BorderStyle::DoubleLeftRight,
             border_color: Color::Green,
             margin: 1,
             width: 78,
             flex_direction: FlexDirection::Column,
         ) {
-            Box(margin_top: -1) {
+            View(margin_top: -1) {
                 Text(content: " Overlap Example ", wrap: TextWrap::NoWrap)
             }
-            Box(padding: 1) {
+            View(padding: 1) {
                 Text(content: format!("{} {}", LOREM_IPSUM, LOREM_IPSUM), color: Color::DarkGrey, weight: Weight::Light)
             }
-            Box(
+            View(
                 border_color: Color::Red,
                 border_style: BorderStyle::DoubleTopBottom,
                 padding: 1,
@@ -34,7 +34,7 @@ fn main() {
             ) {
                 Text(content: "This element is overlapping the text!")
             }
-            Box(
+            View(
                 background_color: Color::Reset,
                 border_color: Color::Red,
                 border_style: BorderStyle::DoubleTopBottom,

--- a/examples/progress_bar.rs
+++ b/examples/progress_bar.rs
@@ -18,11 +18,11 @@ fn ProgressBar(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     }
 
     element! {
-        Box {
-            Box(border_style: BorderStyle::Round, border_color: Color::Blue, width: 60) {
-                Box(width: Percent(progress.get()), height: 1, background_color: Color::Green)
+        View {
+            View(border_style: BorderStyle::Round, border_color: Color::Blue, width: 60) {
+                View(width: Percent(progress.get()), height: 1, background_color: Color::Green)
             }
-            Box(padding: 1) {
+            View(padding: 1) {
                 Text(content: format!("{:.0}%", progress))
             }
         }

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -25,7 +25,7 @@ struct UsersTableProps<'a> {
 #[component]
 fn UsersTable<'a>(props: &UsersTableProps<'a>) -> impl Into<AnyElement<'a>> {
     element! {
-        Box(
+        View(
             margin_top: 1,
             margin_bottom: 1,
             flex_direction: FlexDirection::Column,
@@ -33,31 +33,31 @@ fn UsersTable<'a>(props: &UsersTableProps<'a>) -> impl Into<AnyElement<'a>> {
             border_style: BorderStyle::Round,
             border_color: Color::Cyan,
         ) {
-            Box(border_style: BorderStyle::Single, border_edges: Edges::Bottom, border_color: Color::Grey) {
-                Box(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
+            View(border_style: BorderStyle::Single, border_edges: Edges::Bottom, border_color: Color::Grey) {
+                View(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
                     Text(content: "Id", weight: Weight::Bold, decoration: TextDecoration::Underline)
                 }
 
-                Box(width: 40pct) {
+                View(width: 40pct) {
                     Text(content: "Name", weight: Weight::Bold, decoration: TextDecoration::Underline)
                 }
 
-                Box(width: 50pct) {
+                View(width: 50pct) {
                     Text(content: "Email", weight: Weight::Bold, decoration: TextDecoration::Underline)
                 }
             }
 
             #(props.users.map(|users| users.iter().enumerate().map(|(i, user)| element! {
-                Box(background_color: if i % 2 == 0 { None } else { Some(Color::DarkGrey) }) {
-                    Box(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
+                View(background_color: if i % 2 == 0 { None } else { Some(Color::DarkGrey) }) {
+                    View(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
                         Text(content: user.id.to_string())
                     }
 
-                    Box(width: 40pct) {
+                    View(width: 40pct) {
                         Text(content: user.name.clone())
                     }
 
-                    Box(width: 50pct) {
+                    View(width: 50pct) {
                         Text(content: user.email.clone())
                     }
                 }

--- a/examples/use_input.rs
+++ b/examples/use_input.rs
@@ -33,13 +33,13 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     }
 
     element! {
-        Box(
+        View(
             flex_direction: FlexDirection::Column,
             padding: 2,
             align_items: AlignItems::Center
         ) {
             Text(content: "Use arrow keys to move. Press \"q\" to exit.")
-            Box(
+            View(
                 border_style: BorderStyle::Round,
                 border_color: Color::Green,
                 height: AREA_HEIGHT + 2,
@@ -47,7 +47,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             ) {
                 #(if should_exit.get() {
                     element! {
-                        Box(
+                        View(
                             width: 100pct,
                             height: 100pct,
                             justify_content: JustifyContent::Center,
@@ -58,7 +58,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     }
                 } else {
                     element! {
-                        Box(
+                        View(
                             padding_left: x.get(),
                             padding_top: y.get(),
                         ) {

--- a/examples/use_output.rs
+++ b/examples/use_output.rs
@@ -14,7 +14,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     });
 
     element! {
-        Box(border_style: BorderStyle::Round, border_color: Color::Green) {
+        View(border_style: BorderStyle::Round, border_color: Color::Green) {
             Text(content: "Hello, use_stdio!")
         }
     }

--- a/examples/weather.rs
+++ b/examples/weather.rs
@@ -137,7 +137,7 @@ fn LoadingIndicator(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         }
     });
     element! {
-        Box(
+        View(
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             width: 100pct,
@@ -157,11 +157,11 @@ struct WeatherDataViewProps {
 #[component]
 fn WeatherDataView(props: &WeatherDataViewProps) -> impl Into<AnyElement<'static>> {
     element! {
-        Box(
+        View(
             flex_direction: FlexDirection::Column,
             width: 100pct,
         ) {
-            Box(
+            View(
                 flex_direction: FlexDirection::Column,
                 border_style: BorderStyle::Single,
                 border_color: Color::DarkGrey,
@@ -169,28 +169,28 @@ fn WeatherDataView(props: &WeatherDataViewProps) -> impl Into<AnyElement<'static
                 align_items: AlignItems::Center,
                 width: 100pct,
             ) {
-                Box {
+                View {
                     Text(content: "Weather for ")
                     Text(content: format!("{}, {}, {}", props.data.location.city, props.data.location.region, props.data.location.country))
                 }
                 Text(content: format!("{}º, {}º", props.data.location.lat, props.data.location.lon), color: Color::DarkGrey)
             }
-            Box(
+            View(
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
             ) {
-                Box(padding: 1) {
+                View(padding: 1) {
                     Text(content: format!("{} {} {}", props.data.current.emoji(), props.data.current.description(), props.data.current.emoji()), color: props.data.current.color())
                 }
-                Box {
+                View {
                     Text(content: "Temperature: ", weight: Weight::Bold)
                     Text(content: format!("{:.1}{}", props.data.current.temperature_2m, props.data.current_units.temperature_2m))
                 }
-                Box {
+                View {
                     Text(content: "Humidity: ", weight: Weight::Bold)
                     Text(content: format!("{:.1}{}", props.data.current.relative_humidity_2m, props.data.current_units.relative_humidity_2m))
                 }
-                Box {
+                View {
                     Text(content: "Chance of Precipitation: ", weight: Weight::Bold)
                     Text(content: format!("{:.1}{}", props.data.current.precipitation_probability, props.data.current_units.precipitation_probability))
                 }
@@ -237,7 +237,7 @@ fn Weather(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     }
 
     element! {
-        Box(
+        View(
             width: 70,
             height: 14,
             margin: 1,
@@ -245,7 +245,7 @@ fn Weather(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             border_color: Color::Cyan,
             flex_direction: FlexDirection::Column,
         ) {
-            Box(
+            View(
                 flex_grow: 1.0,
             ) {
                 #(match &*state.read() {
@@ -253,7 +253,7 @@ fn Weather(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         WeatherDataView(data: data.clone())
                     }.into_any(),
                     WeatherState::Loaded(Err(err)) => element! {
-                        Box(
+                        View(
                             flex_direction: FlexDirection::Column,
                             justify_content: JustifyContent::Center,
                             align_items: AlignItems::Center,
@@ -268,7 +268,7 @@ fn Weather(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     _ => element!(LoadingIndicator).into_any(),
                 })
             }
-            Box(
+            View(
                 width: 100pct,
                 border_style: BorderStyle::Single,
                 border_color: Color::DarkGrey,

--- a/packages/iocraft-macros/src/lib.rs
+++ b/packages/iocraft-macros/src/lib.rs
@@ -484,7 +484,7 @@ impl ToTokens for ParsedComponent {
 /// #[component]
 /// fn UsersTable<'a>(props: &UsersTableProps<'a>) -> impl Into<AnyElement<'a>> {
 ///     element! {
-///         Box(
+///         View(
 ///             margin_top: 1,
 ///             margin_bottom: 1,
 ///             flex_direction: FlexDirection::Column,
@@ -492,31 +492,31 @@ impl ToTokens for ParsedComponent {
 ///             border_style: BorderStyle::Round,
 ///             border_color: Color::Cyan,
 ///         ) {
-///             Box(border_style: BorderStyle::Single, border_edges: Edges::Bottom, border_color: Color::Grey) {
-///                 Box(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
+///             View(border_style: BorderStyle::Single, border_edges: Edges::Bottom, border_color: Color::Grey) {
+///                 View(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
 ///                     Text(content: "Id", weight: Weight::Bold, decoration: TextDecoration::Underline)
 ///                 }
 ///
-///                 Box(width: 40pct) {
+///                 View(width: 40pct) {
 ///                     Text(content: "Name", weight: Weight::Bold, decoration: TextDecoration::Underline)
 ///                 }
 ///
-///                 Box(width: 50pct) {
+///                 View(width: 50pct) {
 ///                     Text(content: "Email", weight: Weight::Bold, decoration: TextDecoration::Underline)
 ///                 }
 ///             }
 ///
 ///             #(props.users.map(|users| users.iter().enumerate().map(|(i, user)| element! {
-///                 Box(background_color: if i % 2 == 0 { None } else { Some(Color::DarkGrey) }) {
-///                     Box(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
+///                 View(background_color: if i % 2 == 0 { None } else { Some(Color::DarkGrey) }) {
+///                     View(width: 10pct, justify_content: JustifyContent::End, padding_right: 2) {
 ///                         Text(content: user.id.to_string())
 ///                     }
 ///
-///                     Box(width: 40pct) {
+///                     View(width: 40pct) {
 ///                         Text(content: user.name.clone())
 ///                     }
 ///
-///                     Box(width: 50pct) {
+///                     View(width: 50pct) {
 ///                         Text(content: user.email.clone())
 ///                     }
 ///                 }
@@ -539,7 +539,7 @@ impl ToTokens for ParsedComponent {
 /// fn MyGenericComponent<T: Send + Sync + 'static>(
 ///     _props: &MyGenericComponentProps<T>,
 /// ) -> impl Into<AnyElement<'static>> {
-///     element!(Box)
+///     element!(View)
 /// }
 /// ```
 ///

--- a/packages/iocraft-macros/tests/component.rs
+++ b/packages/iocraft-macros/tests/component.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
-use iocraft::{components::Box, AnyElement, Hooks};
+use iocraft::{components::View, AnyElement, Hooks};
 use iocraft_macros::{component, element, Props};
 
 #[component]
 fn MyComponent() -> impl Into<AnyElement<'static>> {
-    element!(Box)
+    element!(View)
 }
 
 #[derive(Default, Props)]
@@ -15,17 +15,17 @@ struct MyProps {
 
 #[component]
 fn MyComponentWithProps(_props: &mut MyProps) -> impl Into<AnyElement<'static>> {
-    element!(Box)
+    element!(View)
 }
 
 #[component]
 fn MyComponentWithHooks(_hooks: Hooks) -> impl Into<AnyElement<'static>> {
-    element!(Box)
+    element!(View)
 }
 
 #[component]
 fn MyComponentWithHooksRef(_hooks: &mut Hooks) -> impl Into<AnyElement<'static>> {
-    element!(Box)
+    element!(View)
 }
 
 #[derive(Props)]
@@ -37,7 +37,7 @@ struct MyGenericProps<T: Send + Sync, const U: usize> {
 fn MyComponentWithGenericProps<T: Send + Sync + 'static, const U: usize>(
     _props: &mut MyGenericProps<T, U>,
 ) -> impl Into<AnyElement<'static>> {
-    element!(Box)
+    element!(View)
 }
 
 fn check_component_traits<T: Send + Sync>() {}
@@ -53,5 +53,5 @@ fn MyComponentWithGenericPropsWhereClause<T, const U: usize>(
 where
     T: Send + Sync + 'static,
 {
-    element!(Box)
+    element!(View)
 }

--- a/packages/iocraft-macros/tests/element.rs
+++ b/packages/iocraft-macros/tests/element.rs
@@ -67,7 +67,7 @@ fn fully_qualified_type() {
         }
     }
     let _: Element<MyComponent> = element!(foo::bar::MyComponent);
-    let _: Element<::iocraft::components::Box> = element!(::iocraft::components::Box);
+    let _: Element<::iocraft::components::View> = element!(::iocraft::components::View);
 }
 
 #[test]

--- a/packages/iocraft/src/components/button.rs
+++ b/packages/iocraft/src/components/button.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component, components::Box, element, hooks::UseTerminalEvents, AnyElement,
+    component, components::View, element, hooks::UseTerminalEvents, AnyElement,
     FullscreenMouseEvent, Handler, Hooks, KeyCode, KeyEvent, KeyEventKind, MouseEventKind, Props,
     TerminalEvent,
 };
@@ -32,7 +32,7 @@ pub struct ButtonProps<'a> {
 /// # fn foo() -> impl Into<AnyElement<'static>> {
 /// element! {
 ///     Button(handler: |_| { /* do something */ }, has_focus: true) {
-///         Box(border_style: BorderStyle::Round, border_color: Color::Blue) {
+///         View(border_style: BorderStyle::Round, border_color: Color::Blue) {
 ///             Text(content: "Click me!")
 ///         }
 ///     }
@@ -64,7 +64,7 @@ pub fn Button<'a>(mut hooks: Hooks, props: &mut ButtonProps<'a>) -> impl Into<An
 
     match props.children.iter_mut().next() {
         Some(child) => child.into(),
-        None => element!(Box).into_any(),
+        None => element!(View).into_any(),
     }
 }
 

--- a/packages/iocraft/src/components/context_provider.rs
+++ b/packages/iocraft/src/components/context_provider.rs
@@ -27,7 +27,7 @@ pub struct ContextProviderProps<'a> {
 ///     let number = hooks.use_context::<NumberOfTheDay>();
 ///
 ///     element! {
-///         Box(border_style: BorderStyle::Round, border_color: Color::Cyan) {
+///         View(border_style: BorderStyle::Round, border_color: Color::Cyan) {
 ///             Text(content: "The number of the day is... ")
 ///             Text(color: Color::Green, weight: Weight::Bold, content: number.0.to_string())
 ///             Text(content: "!")

--- a/packages/iocraft/src/components/mod.rs
+++ b/packages/iocraft/src/components/mod.rs
@@ -1,6 +1,3 @@
-mod r#box;
-pub use r#box::*;
-
 mod button;
 pub use button::*;
 
@@ -12,3 +9,6 @@ pub use text::*;
 
 mod text_input;
 pub use text_input::*;
+
+mod view;
+pub use view::*;

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -199,7 +199,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 14) {
+                View(width: 14) {
                     Text(content: "this is a wrapping test")
                 }
             }
@@ -209,7 +209,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 15) {
+                View(width: 15) {
                     Text(content: "this is an alignment test", align: TextAlign::Right)
                 }
             }
@@ -219,7 +219,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 15) {
+                View(width: 15) {
                     Text(content: "this is an alignment test", align: TextAlign::Center)
                 }
             }

--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -29,7 +29,7 @@ pub struct TextInputProps {
 /// `TextInput` is a component that can receive text input from the user.
 ///
 /// It will fill the available space and display the current value. Typically, you will want to
-/// render it in a [`Box`] component of the desired text field size.
+/// render it in a [`View`](crate::components::View) component of the desired text field size.
 ///
 /// # Example
 ///
@@ -40,14 +40,14 @@ pub struct TextInputProps {
 /// let mut value = hooks.use_state(|| "".to_string());
 ///
 /// element! {
-///     Box(
+///     View(
 ///         border_style: BorderStyle::Round,
 ///         border_color: Color::Blue,
 ///     ) {
-///         Box(width: 15) {
+///         View(width: 15) {
 ///             Text(content: "Input: ")
 ///         }
-///         Box(
+///         View(
 ///             background_color: Color::DarkGrey,
 ///             width: 30,
 ///         ) {
@@ -179,7 +179,7 @@ mod tests {
         }
 
         element! {
-            Box(height: 1, width: 10) {
+            View(height: 1, width: 10) {
                 TextInput(
                     has_focus: true,
                     value: value.to_string(),

--- a/packages/iocraft/src/components/view.rs
+++ b/packages/iocraft/src/components/view.rs
@@ -5,7 +5,7 @@ use crate::{
 use iocraft_macros::with_layout_style_props;
 use taffy::{LengthPercentage, Rect};
 
-/// A border style which can be applied to a [`Box`].
+/// A border style which can be applied to a [`View`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BorderStyle {
     /// No border.
@@ -29,7 +29,7 @@ pub enum BorderStyle {
     Custom(BorderCharacters),
 }
 
-/// The characters used to render a custom border for a [`Box`].
+/// The characters used to render a custom border for a [`View`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BorderCharacters {
     /// The character used for the top-left corner.
@@ -135,15 +135,15 @@ impl BorderStyle {
     }
 }
 
-/// The props which can be passed to the [`Box`] component.
+/// The props which can be passed to the [`View`] component.
 #[non_exhaustive]
 #[with_layout_style_props]
 #[derive(Default, Props)]
-pub struct BoxProps<'a> {
-    /// The elements to render inside of the box.
+pub struct ViewProps<'a> {
+    /// The elements to render inside of the view.
     pub children: Vec<AnyElement<'a>>,
 
-    /// The style of the border. By default, the box will have no border.
+    /// The style of the border. By default, the view will have no border.
     pub border_style: BorderStyle,
 
     /// The color of the border.
@@ -156,7 +156,7 @@ pub struct BoxProps<'a> {
     pub background_color: Option<Color>,
 }
 
-/// `Box` is your most fundamental building block for laying out and styling components.
+/// `View` is your most fundamental building block for laying out and styling components.
 ///
 /// # Example
 ///
@@ -164,22 +164,22 @@ pub struct BoxProps<'a> {
 /// # use iocraft::prelude::*;
 /// # fn my_element() -> impl Into<AnyElement<'static>> {
 /// element! {
-///     Box(padding: 2, border_style: BorderStyle::Round) {
+///     View(padding: 2, border_style: BorderStyle::Round) {
 ///         Text(content: "Hello!")
 ///     }
 /// }
 /// # }
 /// ```
 #[derive(Default)]
-pub struct Box {
+pub struct View {
     border_style: BorderStyle,
     border_text_style: CanvasTextStyle,
     border_edges: Edges,
     background_color: Option<Color>,
 }
 
-impl Component for Box {
-    type Props<'a> = BoxProps<'a>;
+impl Component for View {
+    type Props<'a> = ViewProps<'a>;
 
     fn new(_props: &Self::Props<'_>) -> Self {
         Default::default()
@@ -359,12 +359,12 @@ mod tests {
     }
 
     #[test]
-    fn test_box() {
-        assert_eq!(element!(Box).to_string(), "");
+    fn test_view() {
+        assert_eq!(element!(View).to_string(), "");
 
         assert_eq!(
             element! {
-                Box {
+                View {
                     Text(content: "foo")
                     Text(content: "bar")
                 }
@@ -375,7 +375,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(padding: 1) {
+                View(padding: 1) {
                     Text(content: "foo")
                 }
             }
@@ -385,7 +385,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(margin: 2) {
+                View(margin: 2) {
                     Text(content: "foo")
                 }
             }
@@ -395,11 +395,11 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 20) {
-                    Box(width: 60pct) {
+                View(width: 20) {
+                    View(width: 60pct) {
                         Text(content: "foo")
                     }
-                    Box(width: 40pct) {
+                    View(width: 40pct) {
                         Text(content: "bar")
                     }
                 }
@@ -410,11 +410,11 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 20, border_style: BorderStyle::Single) {
-                    Box(width: 60pct) {
+                View(width: 20, border_style: BorderStyle::Single) {
+                    View(width: 60pct) {
                         Text(content: "foo")
                     }
-                    Box(width: 40pct) {
+                    View(width: 40pct) {
                         Text(content: "bar")
                     }
                 }
@@ -429,30 +429,30 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(flex_direction: FlexDirection::Column) {
-                    Box {
-                        Box(border_style: BorderStyle::Single, margin_right: 2) {
+                View(flex_direction: FlexDirection::Column) {
+                    View {
+                        View(border_style: BorderStyle::Single, margin_right: 2) {
                             Text(content: "Single")
                         }
-                        Box(border_style: BorderStyle::Double, margin_right: 2) {
+                        View(border_style: BorderStyle::Double, margin_right: 2) {
                             Text(content: "Double")
                         }
-                        Box(border_style: BorderStyle::Round, margin_right: 2) {
+                        View(border_style: BorderStyle::Round, margin_right: 2) {
                             Text(content: "Round")
                         }
-                        Box(border_style: BorderStyle::Bold) {
+                        View(border_style: BorderStyle::Bold) {
                             Text(content: "Bold")
                         }
                     }
 
-                    Box(margin_top: 1) {
-                        Box(border_style: BorderStyle::DoubleLeftRight, margin_right: 2) {
+                    View(margin_top: 1) {
+                        View(border_style: BorderStyle::DoubleLeftRight, margin_right: 2) {
                             Text(content: "DoubleLeftRight")
                         }
-                        Box(border_style: BorderStyle::DoubleTopBottom, margin_right: 2) {
+                        View(border_style: BorderStyle::DoubleTopBottom, margin_right: 2) {
                             Text(content: "DoubleTopBottom")
                         }
-                        Box(border_style: BorderStyle::Classic) {
+                        View(border_style: BorderStyle::Classic) {
                             Text(content: "Classic")
                         }
                     }
@@ -472,7 +472,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
+                View(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
                     Text(content: "✅")
                 }
             }
@@ -488,7 +488,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
+                View(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
                     Text(content: "☀️")
                 }
             }
@@ -502,7 +502,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
+                View(width: 8, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
                     Text(content: "☀️☀️")
                 }
             }
@@ -516,7 +516,7 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 12, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
+                View(width: 12, border_style: BorderStyle::Single, justify_content: JustifyContent::Center) {
                     Text(content: "フーバー")
                 }
             }
@@ -530,11 +530,11 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(
+                View(
                     border_style: BorderStyle::Round,
                     flex_direction: FlexDirection::Column,
                 ) {
-                    Box(
+                    View(
                         margin_top: -1,
                     ) {
                         Text(content: "Title")
@@ -552,9 +552,9 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box {
+                View {
                     Text(content: "This is the background text.")
-                    Box(
+                    View(
                         position: Position::Absolute,
                         top: 0,
                         left: 3,
@@ -569,9 +569,9 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box {
+                View {
                     Text(content: "This is the background text.")
-                    Box(
+                    View(
                         position: Position::Absolute,
                         top: 0,
                         left: 3,
@@ -587,11 +587,11 @@ mod tests {
 
         assert_eq!(
             element! {
-                Box(width: 20, border_style: BorderStyle::Single, column_gap: 2) {
-                    Box(width: 3) {
+                View(width: 20, border_style: BorderStyle::Single, column_gap: 2) {
+                    View(width: 3) {
                         Text(content: "foo")
                     }
-                    Box(width: 3) {
+                    View(width: 3) {
                         Text(content: "bar")
                     }
                 }
@@ -607,7 +607,7 @@ mod tests {
         // regression test for https://github.com/ccbrown/iocraft/issues/52
         assert_eq!(
             element! {
-                Box(width: 20, border_style: BorderStyle::Single, row_gap: 1, flex_direction: FlexDirection::Column) {
+                View(width: 20, border_style: BorderStyle::Single, row_gap: 1, flex_direction: FlexDirection::Column) {
                     Text(content: "foo")
                     MyText(content: "bar")
                     MyText(content: "baz")

--- a/packages/iocraft/src/element.rs
+++ b/packages/iocraft/src/element.rs
@@ -236,7 +236,7 @@ pub trait ElementExt: private::Sealed + Sized {
     /// # use futures::stream::StreamExt;
     /// # #[component]
     /// # fn MyTextInput() -> impl Into<AnyElement<'static>> {
-    /// #     element!(Box)
+    /// #     element!(View)
     /// # }
     /// async fn test_text_input() {
     ///     let actual = element!(MyTextInput)
@@ -417,18 +417,18 @@ mod tests {
     #[allow(clippy::unnecessary_mut_passed)]
     #[test]
     fn test_element() {
-        let mut box_element = element!(Box);
-        box_element.key();
-        box_element.print();
-        box_element.eprint();
-        (&mut box_element).key();
-        (&mut box_element).print();
-        (&mut box_element).eprint();
+        let mut view_element = element!(View);
+        view_element.key();
+        view_element.print();
+        view_element.eprint();
+        (&mut view_element).key();
+        (&mut view_element).print();
+        (&mut view_element).eprint();
 
         #[cfg(unix)]
-        box_element.write_to_raw_fd(std::io::stdout()).unwrap();
+        view_element.write_to_raw_fd(std::io::stdout()).unwrap();
 
-        let mut any_element: AnyElement<'static> = box_element.into_any();
+        let mut any_element: AnyElement<'static> = view_element.into_any();
         any_element.key();
         any_element.print();
         any_element.eprint();
@@ -436,8 +436,8 @@ mod tests {
         (&mut any_element).print();
         (&mut any_element).eprint();
 
-        let mut box_element = element!(Box);
-        let mut any_element_ref: AnyElement = (&mut box_element).into();
+        let mut view_element = element!(View);
+        let mut any_element_ref: AnyElement = (&mut view_element).into();
         any_element_ref.print();
         any_element_ref.eprint();
     }

--- a/packages/iocraft/src/hooks/use_async_handler.rs
+++ b/packages/iocraft/src/hooks/use_async_handler.rs
@@ -92,7 +92,7 @@ mod tests {
             exit(());
         }
 
-        element!(Box)
+        element!(View)
     }
 
     #[apply(test!)]

--- a/packages/iocraft/src/hooks/use_context.rs
+++ b/packages/iocraft/src/hooks/use_context.rs
@@ -26,7 +26,7 @@ mod private {
 ///     let number = hooks.use_context::<NumberOfTheDay>();
 ///
 ///     element! {
-///         Box(border_style: BorderStyle::Round, border_color: Color::Cyan) {
+///         View(border_style: BorderStyle::Round, border_color: Color::Cyan) {
 ///             Text(content: "The number of the day is... ")
 ///             Text(color: Color::Green, weight: Weight::Bold, content: number.0.to_string())
 ///             Text(content: "!")

--- a/packages/iocraft/src/hooks/use_output.rs
+++ b/packages/iocraft/src/hooks/use_output.rs
@@ -31,7 +31,7 @@ mod private {
 ///     });
 ///
 ///     element! {
-///         Box(border_style: BorderStyle::Round, border_color: Color::Green) {
+///         View(border_style: BorderStyle::Round, border_color: Color::Green) {
 ///             Text(content: "Hello, use_stdio!")
 ///         }
 ///     }
@@ -201,7 +201,7 @@ mod tests {
         stdout.println("Hello, world!");
         stderr.println("Hello, error!");
         system.exit();
-        element!(Box)
+        element!(View)
     }
 
     #[apply(test!)]

--- a/packages/iocraft/src/hooks/use_terminal_events.rs
+++ b/packages/iocraft/src/hooks/use_terminal_events.rs
@@ -50,13 +50,13 @@ mod private {
 ///     }
 ///
 ///     element! {
-///         Box(
+///         View(
 ///             flex_direction: FlexDirection::Column,
 ///             padding: 2,
 ///             align_items: AlignItems::Center
 ///         ) {
 ///             Text(content: "Use arrow keys to move. Press \"q\" to exit.")
-///             Box(
+///             View(
 ///                 border_style: BorderStyle::Round,
 ///                 border_color: Color::Green,
 ///                 height: AREA_HEIGHT + 2,
@@ -64,7 +64,7 @@ mod private {
 ///             ) {
 ///                 #(if should_exit.get() {
 ///                     element! {
-///                         Box(
+///                         View(
 ///                             width: 100pct,
 ///                             height: 100pct,
 ///                             justify_content: JustifyContent::Center,
@@ -75,7 +75,7 @@ mod private {
 ///                     }
 ///                 } else {
 ///                     element! {
-///                         Box(
+///                         View(
 ///                             padding_left: x.get(),
 ///                             padding_top: y.get(),
 ///                         ) {
@@ -206,7 +206,7 @@ mod tests {
             system.exit();
             element!(Text(content:"received event")).into_any()
         } else {
-            element!(Box).into_any()
+            element!(View).into_any()
         }
     }
 
@@ -249,14 +249,14 @@ mod tests {
             system.exit();
             element!(Text(content:"received click")).into_any()
         } else {
-            element!(Box(width: 10, height: 10)).into_any()
+            element!(View(width: 10, height: 10)).into_any()
         }
     }
 
     #[apply(test!)]
     async fn test_use_local_terminal_events() {
         let canvases: Vec<_> = element! {
-            Box(padding: 2) {
+            View(padding: 2) {
                 MyClickableComponent
             }
         }

--- a/packages/iocraft/src/lib.rs
+++ b/packages/iocraft/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! fn main() {
 //!     element! {
-//!         Box(
+//!         View(
 //!             border_style: BorderStyle::Round,
 //!             border_color: Color::Blue,
 //!         ) {
@@ -40,7 +40,7 @@
 //! elements in a React/SwiftUI-like syntax.
 //!
 //! `iocraft` provides a few built-in components in the [`components`] module, such as
-//! [`Box`](crate::components::Box), [`Text`](crate::components::Text), and
+//! [`View`](crate::components::View), [`Text`](crate::components::Text), and
 //! [`TextInput`](crate::components::TextInput), but you can also create your own using the
 //! [`macro@component`] macro.
 //!
@@ -124,20 +124,20 @@ mod flattened_exports {
     ///
     /// ```
     /// # use iocraft::prelude::*;
-    /// # fn my_element() -> Element<'static, Box> {
-    /// element!(Box)
+    /// # fn my_element() -> Element<'static, View> {
+    /// element!(View)
     /// # }
     /// ```
     ///
-    /// This will evaluate to an [`Element`]`<'static, `[`Box`](crate::components::Box)`>` with no properties set.
+    /// This will evaluate to an [`Element`]`<'static, `[`View`](crate::components::View)`>` with no properties set.
     ///
     /// To specify properties, you can add them in a parenthesized block after the type name:
     ///
     /// ```
     /// # use iocraft::prelude::*;
-    /// # fn my_element() -> Element<'static, Box> {
+    /// # fn my_element() -> Element<'static, View> {
     /// element! {
-    ///     Box(width: 80, height: 24, background_color: Color::Green)
+    ///     View(width: 80, height: 24, background_color: Color::Green)
     /// }
     /// # }
     /// ```
@@ -146,9 +146,9 @@ mod flattened_exports {
     ///
     /// ```
     /// # use iocraft::prelude::*;
-    /// # fn my_element() -> Element<'static, Box> {
+    /// # fn my_element() -> Element<'static, View> {
     /// element! {
-    ///     Box {
+    ///     View {
     ///         Text(content: "Hello, world!")
     ///     }
     /// }
@@ -160,9 +160,9 @@ mod flattened_exports {
     ///
     /// ```
     /// # use iocraft::prelude::*;
-    /// # fn my_element(show_greeting: bool) -> Element<'static, Box> {
+    /// # fn my_element(show_greeting: bool) -> Element<'static, View> {
     /// element! {
-    ///     Box {
+    ///     View {
     ///         #(if show_greeting {
     ///             Some(element! {
     ///                 Text(content: "Hello, world!")
@@ -183,11 +183,11 @@ mod flattened_exports {
     /// ```
     /// # use iocraft::prelude::*;
     /// # struct User { id: i32, name: String }
-    /// # fn my_element(users: Vec<User>) -> Element<'static, Box> {
+    /// # fn my_element(users: Vec<User>) -> Element<'static, View> {
     /// element! {
-    ///     Box {
+    ///     View {
     ///         #(users.iter().map(|user| element! {
-    ///             Box(key: user.id, flex_direction: FlexDirection::Column) {
+    ///             View(key: user.id, flex_direction: FlexDirection::Column) {
     ///                 Text(content: format!("Hello, {}!", user.name))
     ///             }
     ///         }))

--- a/packages/iocraft/src/render.rs
+++ b/packages/iocraft/src/render.rs
@@ -512,7 +512,7 @@ mod tests {
         }
 
         element! {
-            Box(flex_direction: FlexDirection::Column) {
+            View(flex_direction: FlexDirection::Column) {
                 Text(content: format!("tick: {}", tick))
                 MyInnerComponent(label: "a")
                 #((0..2).map(|i| element! { MyInnerComponent(label: format!("b{}", i)) }))
@@ -549,7 +549,7 @@ mod tests {
     #[component]
     fn FullWidthComponent() -> impl Into<AnyElement<'static>> {
         element! {
-            Box(height: 2, width: 100pct, border_style: BorderStyle::Classic)
+            View(height: 2, width: 100pct, border_style: BorderStyle::Classic)
         }
     }
 
@@ -558,7 +558,7 @@ mod tests {
         // For layout purposes, components defined with #[component] should not introduce a new
         // node in between its parent and child.
         let actual = element! {
-            Box(width: 10) {
+            View(width: 10) {
                 FullWidthComponent
             }
         }
@@ -580,7 +580,7 @@ mod tests {
         hooks.use_future(async move {
             ticks += 1;
         });
-        element!(Box)
+        element!(View)
     }
 
     #[component]
@@ -603,7 +603,7 @@ mod tests {
         }
 
         element! {
-            Box {
+            View {
                 #((0..10).map(|_| {
                     element! {
                         AsyncTicker(ticks: child_ticks)


### PR DESCRIPTION
## What It Does

Renames `Box` to `View` to avoid conflict with `std::boxed::Box`.

## Related Issues

- https://github.com/ccbrown/iocraft/issues/42
