### PR TITLE
Fix for overflow when scrolling out of bounds.

### DIFF
--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -345,8 +345,8 @@ impl CanvasSubviewMut<'_> {
         self.canvas.set_background_color(
             left as _,
             top as _,
-            (right - left) as _,
-            (bottom - top) as _,
+            (right - left).max(0) as _,
+            (bottom - top).max(0) as _,
             color,
         );
     }
@@ -366,8 +366,8 @@ impl CanvasSubviewMut<'_> {
         self.canvas.clear_text(
             left as _,
             top as _,
-            (right - left) as _,
-            (bottom - top) as _,
+            (right - left).max(0) as _,
+            (bottom - top).max(0) as _,
         );
     }
 


### PR DESCRIPTION
## What It Does

If a background_color is set on the view, and it is scrolled out of view by moving the canvas up or left, overflow can happen because here we are bypassing a proper cast to an usize. This leads to addition overflow in the called method `Canvas::set_background_color` and `Canvas::clear_text`, both of which expect a usize as their inputs.


## Related Issues

This is related to #68. I was using the second implementation in the issue, and when i added a background_color to my views, it would crash when the scrolled content is moved far enough out of the top section that the inner calculation for clearing the canvas would overflow [here](https://github.com/ccbrown/iocraft/blob/main/packages/iocraft/src/canvas.rs#L114).
