### PR TITLE
fix: don't erase last col for fullscreen tuis

### DIFF
--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -362,8 +362,7 @@ fn App(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
     element! {
         View(
-            // subtract one in case there's a scrollbar
-            width: width - 1,
+            width,
             height: height,
             background_color: theme.get().background_color(),
             flex_direction: FlexDirection::Column,

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -34,8 +34,7 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
     element! {
         View(
-            // subtract one in case there's a scrollbar
-            width: width - 1,
+            width,
             height,
             background_color: Color::DarkGrey,
             border_style: BorderStyle::Double,


### PR DESCRIPTION
## What It Does

Previously, we emitted an ANSI "erase in line" sequence at the end of each line. This was a problem for fullscreen apps, where the cursor position after writing out a full line was on top of the last character rather than after it. As a result, the last character was being erased. This rearranges the ANSI output for full lines to ensure that the last character is correctly written.

## Related Issues

- https://github.com/ccbrown/iocraft/issues/83