### PR TITLE
feat: add fragment component and use_const hook

### DIFF
--- a/packages/iocraft/src/components/fragment.rs
+++ b/packages/iocraft/src/components/fragment.rs
@@ -1,0 +1,86 @@
+use crate::{AnyElement, Component, ComponentUpdater, Hooks, Props};
+
+/// The props which can be passed to the [`Fragment`] component.
+#[non_exhaustive]
+#[derive(Default, Props)]
+pub struct FragmentProps<'a> {
+    /// The children of the component.
+    pub children: Vec<AnyElement<'a>>,
+}
+
+/// `Fragment` is a component which allows you to group elements without impacting the resulting
+/// layout.
+///
+/// This is typically used when you want to create a component that returns multiple elements.
+///
+/// # Example
+///
+/// ```
+/// # use iocraft::prelude::*;
+/// #[component]
+/// fn TextLines() -> impl Into<AnyElement<'static>> {
+///     element! {
+///         Fragment {
+///             Text(content: "Line 1")
+///             Text(content: "Line 2")
+///         }
+///     }
+/// }
+///
+/// fn MyComponent() -> impl Into<AnyElement<'static>> {
+///     element! {
+///         View(flex_direction: FlexDirection::Column) {
+///             TextLines
+///         }
+///     }
+/// }
+/// ```
+#[derive(Default)]
+pub struct Fragment;
+
+impl Component for Fragment {
+    type Props<'a> = FragmentProps<'a>;
+
+    fn new(_props: &Self::Props<'_>) -> Self {
+        Self
+    }
+
+    fn update(
+        &mut self,
+        props: &mut Self::Props<'_>,
+        _hooks: Hooks,
+        updater: &mut ComponentUpdater,
+    ) {
+        updater.set_transparent_layout(true);
+        updater.update_children(props.children.iter_mut(), None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[component]
+    fn TextLines() -> impl Into<AnyElement<'static>> {
+        element! {
+            Fragment {
+                Text(content: "Line 1")
+                Text(content: "Line 2")
+            }
+        }
+    }
+
+    #[component]
+    fn MyComponent() -> impl Into<AnyElement<'static>> {
+        element! {
+            View(flex_direction: FlexDirection::Column) {
+                TextLines
+            }
+        }
+    }
+
+    #[test]
+    fn test_fragment() {
+        assert_eq!(element!(MyComponent).to_string(), "Line 1\nLine 2\n");
+    }
+}

--- a/packages/iocraft/src/components/mod.rs
+++ b/packages/iocraft/src/components/mod.rs
@@ -4,6 +4,9 @@ pub use button::*;
 mod context_provider;
 pub use context_provider::*;
 
+mod fragment;
+pub use fragment::*;
+
 mod mixed_text;
 pub use mixed_text::*;
 

--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -44,6 +44,18 @@ impl<'a> UseSize<'a> for Hooks<'a, '_> {
     }
 }
 
+#[derive(Default)]
+struct UseSizeImpl {
+    size: (u16, u16),
+}
+
+impl Hook for UseSizeImpl {
+    fn pre_component_draw(&mut self, drawer: &mut ComponentDrawer) {
+        let s = drawer.size();
+        self.size = (s.width, s.height);
+    }
+}
+
 struct TextBufferRow {
     offset: usize,
     len: usize,
@@ -203,18 +215,6 @@ impl Component for TextBufferView {
     }
 }
 
-#[derive(Default)]
-struct UseSizeImpl {
-    size: (u16, u16),
-}
-
-impl Hook for UseSizeImpl {
-    fn pre_component_draw(&mut self, drawer: &mut ComponentDrawer) {
-        let s = drawer.size();
-        self.size = (s.width, s.height);
-    }
-}
-
 /// `TextInput` is a component that can receive text input from the user.
 ///
 /// It will fill the available width and display the current value. Typically, you will want to
@@ -280,7 +280,7 @@ pub fn TextInput(mut hooks: Hooks, props: &mut TextInputProps) -> impl Into<AnyE
             let text = props.value.clone();
             move || Arc::new(TextBuffer::new(text, max_text_width as _))
         },
-        (&props.value, max_text_width, multiline),
+        (&props.value, max_text_width),
     );
 
     // Update the cursor position if the value has changed.

--- a/packages/iocraft/src/hooks/mod.rs
+++ b/packages/iocraft/src/hooks/mod.rs
@@ -42,6 +42,8 @@
 
 mod use_async_handler;
 pub use use_async_handler::*;
+mod use_const;
+pub use use_const::*;
 mod use_context;
 pub use use_context::*;
 mod use_future;

--- a/packages/iocraft/src/hooks/use_const.rs
+++ b/packages/iocraft/src/hooks/use_const.rs
@@ -1,0 +1,110 @@
+use crate::{Hook, Hooks};
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for crate::Hooks<'_, '_> {}
+}
+
+/// `UseConst` is a hook that allows you to store a value which doesn't change.
+///
+/// It can be used for complex values that are constant across renders or it can be used to create
+/// controllers, caches, channels, or other objects which don't directly impact the component's
+/// output.
+///
+/// It is similar to [`UseMemo`](crate::hooks::UseMemo), but it never recomputes the value. If the
+/// value is dependent on state, props, or other dynamic values, use
+/// [`UseMemo`](crate::hooks::UseMemo) instead.
+///
+/// # Example
+///
+/// ```
+/// # use iocraft::prelude::*;
+/// # use std::sync::Arc;
+/// # #[derive(Clone, Default, Props)]
+/// # struct Data;
+/// # #[derive(Clone, Default, Props)]
+/// # struct DataViewProps {
+/// #     data: Arc<Data>,
+/// # }
+/// # #[component]
+/// # fn DataView(props: &DataViewProps) -> impl Into<AnyElement<'static>> {
+/// #     element!(View)
+/// # }
+/// #[component]
+/// fn MyComponent(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+///     let data: Arc<Data> = hooks.use_const_default();
+///
+///     element! {
+///         DataView(data)
+///     }
+/// }
+/// ```
+pub trait UseConst: private::Sealed {
+    /// Returns a constant value, initialized by the provided function.
+    ///
+    /// The returned value is cloned, so if cloning is expensive, consider using a reference type
+    /// such as [`Arc`](std::sync::Arc).
+    fn use_const<F, T>(&mut self, f: F) -> T
+    where
+        F: FnOnce() -> T,
+        T: Clone + Send + Unpin + 'static;
+
+    /// Returns a constant value, initialized by its default value.
+    ///
+    /// The returned value is cloned, so if cloning is expensive, consider using a reference type
+    /// such as [`Arc`](std::sync::Arc).
+    fn use_const_default<T>(&mut self) -> T
+    where
+        T: Clone + Default + Send + Unpin + 'static;
+}
+
+impl UseConst for Hooks<'_, '_> {
+    fn use_const<F, T>(&mut self, f: F) -> T
+    where
+        F: FnOnce() -> T,
+        T: Clone + Send + Unpin + 'static,
+    {
+        let hook = self.use_hook(move || UseConstImpl { value: f() });
+        hook.value.clone()
+    }
+
+    fn use_const_default<T>(&mut self) -> T
+    where
+        T: Clone + Default + Send + Unpin + 'static,
+    {
+        self.use_const(T::default)
+    }
+}
+
+struct UseConstImpl<T> {
+    value: T,
+}
+
+impl<T: Send + Unpin> Hook for UseConstImpl<T> {}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[derive(Clone, Default)]
+    struct MyStruct(u64);
+
+    #[component]
+    fn MyComponent(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
+        let a = hooks.use_const(|| 42);
+        let b: MyStruct = hooks.use_const_default();
+        let c = hooks.use_const(|| "hello!");
+
+        assert_eq!(a, 42);
+        assert_eq!(b.0, 0);
+        assert_eq!(c, "hello!");
+
+        element!(View)
+    }
+
+    #[test]
+    fn test_use_const() {
+        let s = element!(MyComponent).to_string();
+        assert_eq!(s, "");
+    }
+}


### PR DESCRIPTION
## What It Does

- Adds the `Fragment` component, with the same functionality as in React. This is equivalent to using `ContextProvider` with no props, but is more obvious and conveys intent better.
- Adds the `UseConst` hook for storing constant values in a component.