### PR TITLE
fix: focus logic by arrow up in form example

### DIFF
--- a/examples/form.rs
+++ b/examples/form.rs
@@ -65,7 +65,7 @@ fn Form<'a>(props: &mut FormProps<'a>, mut hooks: Hooks) -> impl Into<AnyElement
                 }
                 KeyCode::BackTab => focus.set((focus + 3) % 4),
                 KeyCode::Tab => focus.set((focus + 1) % 4),
-                KeyCode::Up if focus != 2 => focus.set((focus + 3) % 4),
+                KeyCode::Up if focus != 0 => focus.set((focus + 3) % 4),
                 KeyCode::Down if focus != 2 => focus.set((focus + 1) % 4),
                 _ => {}
             }

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -65,8 +65,6 @@ fn Form<'a>(props: &mut FormProps<'a>, mut hooks: Hooks) -> impl Into<AnyElement
                 }
                 KeyCode::BackTab => focus.set((focus + 3) % 4),
                 KeyCode::Tab => focus.set((focus + 1) % 4),
-                KeyCode::Up if focus != 0 => focus.set((focus + 3) % 4),
-                KeyCode::Down if focus != 2 => focus.set((focus + 1) % 4),
                 _ => {}
             }
         }


### PR DESCRIPTION
## What It Does

in form example, the focused field is controlled by a `focus` State and we update it in terminal events handler, but the `KeyCode::Up` is not correctly used, which will cause wired behavior. 

## Fix

simple fix by disable KeyCode::Up when the focused field is already the first one in the Form