### PR TITLE
feat: automatically append newline as needed for use_output

### DIFF
--- a/examples/use_output.rs
+++ b/examples/use_output.rs
@@ -6,20 +6,20 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let (stdout, stderr) = hooks.use_output();
 
     hooks.use_future(async move {
-        loop {
+        stdout.println("Hello from iocraft to stdout!");
+        stderr.println("  And hello to stderr too!");
+
+        stdout.print("Working...");
+        for _ in 0..5 {
             smol::Timer::after(Duration::from_secs(1)).await;
-            stdout.println("Hello from iocraft to stdout!");
-            stderr.println("  And hello to stderr too!");
-            stdout.print("Using print: ");
-            stdout.print("part1 ");
-            stdout.print("part2 ");
-            stdout.println("done!");
+            stdout.print(".");
         }
+        stdout.println("\nDone!");
     });
 
     element! {
         View(border_style: BorderStyle::Round, border_color: Color::Green) {
-            Text(content: "Hello, use_stdio!")
+            Text(content: "Hello, use_output!")
         }
     }
 }


### PR DESCRIPTION
## What It Does

Follow-up to https://github.com/ccbrown/iocraft/pull/122.

Adds automatic appending of newlines when `use_stdout`'s `print` function is used without a trailing newline.

Updates the example to show how this can be leveraged.

## Related Issues

https://github.com/ccbrown/iocraft/issues/121