### PR TITLE
fix: End synchronized update on StdTerminal drop

### DIFF
--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -282,7 +282,7 @@ impl Drop for StdTerminal {
         if self.fullscreen {
             let _ = queue!(self.dest, terminal::LeaveAlternateScreen);
         }
-        let _ = execute!(self.dest, cursor::Show, terminal::EndSynchronizedUpdate);
+        let _ = execute!(self.dest, cursor::Show);
     }
 }
 

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -282,7 +282,7 @@ impl Drop for StdTerminal {
         if self.fullscreen {
             let _ = queue!(self.dest, terminal::LeaveAlternateScreen);
         }
-        let _ = execute!(self.dest, cursor::Show);
+        let _ = execute!(self.dest, cursor::Show, terminal::EndSynchronizedUpdate);
     }
 }
 


### PR DESCRIPTION
## What It Does

Add `EndSynchronizedUpdate` to the list of executed commands for `impl Drop for StdTerminal`. 

In the general `terminal_render_loop`, terminal executes an enter to synchronized update, but the render may panic mid-update (for example, https://github.com/ccbrown/iocraft/issues/103), which usually causes `StdTerminal` to drop. But it never ends synchronized update which can cause issues. 

In my case, I was trying to run something akin to https://github.com/ccbrown/iocraft/pull/114 in alacritty + zellij, panic mid-update would freeze the terminal rendering (but it would accept input still); just alacritty worked as expected though (so I think it's zellij related, but I have no idea actually how). Ending synchronized update fixed the issue !

## Related Issues

- Originally discovered while trying to panic safely in a fullscreen app: https://github.com/ccbrown/iocraft/issues/103
