### PR TITLE
eliminate any_key dependency

### DIFF
--- a/packages/iocraft/Cargo.toml
+++ b/packages/iocraft/Cargo.toml
@@ -14,7 +14,6 @@ iocraft-macros = { version = "0.2.3", path = "../iocraft-macros" }
 bitflags = "2.6.0"
 unicode-width = "0.1.13"
 generational-box = "0.5.6"
-any_key = "0.1.1"
 
 [dev-dependencies]
 indoc = "2"

--- a/packages/iocraft/src/any_key.rs
+++ b/packages/iocraft/src/any_key.rs
@@ -1,0 +1,45 @@
+use std::{
+    any::Any,
+    fmt,
+    hash::{Hash, Hasher},
+};
+
+pub(crate) trait AnyKey: Any {
+    fn as_any(&self) -> &dyn Any;
+    fn dyn_eq(&self, other: &dyn AnyKey) -> bool;
+    fn dyn_hash(&self, state: &mut dyn Hasher);
+}
+
+impl<T: Any + Eq + Hash> AnyKey for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn dyn_eq(&self, other: &dyn AnyKey) -> bool {
+        other.as_any().downcast_ref::<T>() == Some(self)
+    }
+
+    fn dyn_hash(&self, mut state: &mut dyn Hasher) {
+        self.hash(&mut state);
+    }
+}
+
+impl fmt::Debug for dyn AnyKey + Send + Sync {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_any().fmt(f)
+    }
+}
+
+impl PartialEq for dyn AnyKey + Send + Sync {
+    fn eq(&self, other: &Self) -> bool {
+        self.dyn_eq(other)
+    }
+}
+
+impl Eq for dyn AnyKey + Send + Sync {}
+
+impl Hash for dyn AnyKey + Send + Sync {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.dyn_hash(state)
+    }
+}

--- a/packages/iocraft/src/element.rs
+++ b/packages/iocraft/src/element.rs
@@ -1,10 +1,10 @@
 use crate::{
+    any_key::AnyKey,
     component::{Component, ComponentHelper, ComponentHelperExt},
     mock_terminal_render_loop,
     props::AnyProps,
     render, terminal_render_loop, Canvas, MockTerminalConfig, Terminal,
 };
-use any_key::AnyHash;
 use crossterm::terminal;
 use futures::Stream;
 use std::{
@@ -61,7 +61,7 @@ where
 /// Used to identify an element within the scope of its parent. This is used to minimize the number
 /// of times components are destroyed and recreated from render-to-render.
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
-pub struct ElementKey(Arc<Box<dyn AnyHash + Send + Sync>>);
+pub struct ElementKey(Arc<Box<dyn AnyKey + Send + Sync>>);
 
 impl ElementKey {
     /// Constructs a new key.

--- a/packages/iocraft/src/lib.rs
+++ b/packages/iocraft/src/lib.rs
@@ -93,6 +93,7 @@
 // The exception is the modules that represent collections of types, namely hooks and components.
 // Those types will remain in their modules for the public API.
 
+mod any_key;
 mod canvas;
 mod component;
 mod context;


### PR DESCRIPTION
## What It Does

This replaces the `any_key` dependency with a simple in-crate replacement. The motivation is to eliminate two unmaintained dependencies, one with a known soundness issue.

## Related Issues

Fixes https://github.com/ccbrown/iocraft/issues/153