### PR TITLE
fix: eliminate extra blank line in inline render mode

### DIFF
--- a/packages/iocraft/Cargo.toml
+++ b/packages/iocraft/Cargo.toml
@@ -16,6 +16,7 @@ unicode-width = "0.1.13"
 generational-box = "0.5.6"
 
 [dev-dependencies]
+avt = "0.17"
 indoc = "2"
 smol = "2.0.1"
 smol-macros = "0.1.1"

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -123,6 +123,23 @@ trait TerminalImpl: Write + Send {
     fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>>;
 }
 
+fn clear_canvas_inline(dest: &mut impl Write, prev_canvas_height: u16) -> io::Result<()> {
+    let lines_to_rewind = prev_canvas_height - 1;
+    if lines_to_rewind == 0 {
+        queue!(
+            dest,
+            cursor::MoveToColumn(0),
+            terminal::Clear(terminal::ClearType::FromCursorDown)
+        )
+    } else {
+        queue!(
+            dest,
+            cursor::MoveToPreviousLine(lines_to_rewind as _),
+            terminal::Clear(terminal::ClearType::FromCursorDown)
+        )
+    }
+}
+
 struct StdTerminal {
     input_is_terminal: bool,
     dest: io::Stdout,
@@ -176,20 +193,7 @@ impl TerminalImpl for StdTerminal {
             }
         }
 
-        let lines_to_rewind = self.prev_canvas_height - 1;
-        if lines_to_rewind == 0 {
-            queue!(
-                self.dest,
-                cursor::MoveToColumn(0),
-                terminal::Clear(terminal::ClearType::FromCursorDown)
-            )
-        } else {
-            queue!(
-                self.dest,
-                cursor::MoveToPreviousLine(lines_to_rewind as _),
-                terminal::Clear(terminal::ClearType::FromCursorDown)
-            )
-        }
+        clear_canvas_inline(&mut self.dest, self.prev_canvas_height)
     }
 
     fn write_canvas(&mut self, canvas: &Canvas) -> io::Result<()> {
@@ -543,5 +547,120 @@ mod tests {
         assert!(!terminal.is_raw_mode_enabled());
         let canvas = Canvas::new(10, 1);
         terminal.write_canvas(&canvas).unwrap();
+    }
+
+    fn render_canvas_to_vt(canvas: &Canvas, cols: usize, rows: usize) -> avt::Vt {
+        render_canvases_to_vt(&[canvas], cols, rows)
+    }
+
+    fn render_canvases_to_vt(canvases: &[&Canvas], cols: usize, rows: usize) -> avt::Vt {
+        let mut buf = Vec::new();
+        for (i, canvas) in canvases.iter().enumerate() {
+            if i > 0 {
+                super::clear_canvas_inline(&mut buf, canvases[i - 1].height() as _).unwrap();
+            }
+            canvas.write_ansi_without_final_newline(&mut buf).unwrap();
+        }
+        let mut vt = avt::Vt::new(cols, rows);
+        vt.feed_str(&String::from_utf8(buf).unwrap());
+        vt
+    }
+
+    #[test]
+    fn test_write_canvas_single_line_cursor_position() {
+        let mut canvas = Canvas::new(10, 1);
+        canvas
+            .subview_mut(0, 0, 0, 0, 10, 1)
+            .set_text(0, 0, "hello", CanvasTextStyle::default());
+
+        let vt = render_canvas_to_vt(&canvas, 10, 5);
+
+        assert_eq!(vt.line(0).text(), "hello     ");
+        assert_eq!(vt.cursor().row, 0, "cursor should stay on the first row");
+
+        // clear and rerender with new content
+        let mut canvas2 = Canvas::new(10, 1);
+        canvas2
+            .subview_mut(0, 0, 0, 0, 10, 1)
+            .set_text(0, 0, "world", CanvasTextStyle::default());
+
+        let vt = render_canvases_to_vt(&[&canvas, &canvas2], 10, 5);
+
+        assert_eq!(vt.line(0).text(), "world     ");
+        assert_eq!(vt.cursor().row, 0);
+    }
+
+    #[test]
+    fn test_write_canvas_multi_line_cursor_position() {
+        let mut canvas = Canvas::new(10, 3);
+        canvas
+            .subview_mut(0, 0, 0, 0, 10, 3)
+            .set_text(0, 0, "line1", CanvasTextStyle::default());
+        canvas
+            .subview_mut(0, 0, 0, 0, 10, 3)
+            .set_text(0, 2, "line3", CanvasTextStyle::default());
+
+        let vt = render_canvas_to_vt(&canvas, 10, 5);
+
+        assert_eq!(vt.line(0).text(), "line1     ");
+        assert_eq!(vt.line(1).text(), "          ");
+        assert_eq!(vt.line(2).text(), "line3     ");
+        assert_eq!(
+            vt.cursor().row,
+            2,
+            "cursor should be on the last content row"
+        );
+
+        // clear and rerender with fewer lines
+        let mut canvas2 = Canvas::new(10, 2);
+        canvas2
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 0, "new1", CanvasTextStyle::default());
+        canvas2
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 1, "new2", CanvasTextStyle::default());
+
+        let vt = render_canvases_to_vt(&[&canvas, &canvas2], 10, 5);
+
+        assert_eq!(vt.line(0).text(), "new1      ");
+        assert_eq!(vt.line(1).text(), "new2      ");
+        assert_eq!(
+            vt.line(2).text(),
+            "          ",
+            "old line 3 should be cleared"
+        );
+        assert_eq!(vt.cursor().row, 1);
+    }
+
+    #[test]
+    fn test_write_canvas_no_extra_blank_line() {
+        let mut canvas = Canvas::new(10, 2);
+        canvas
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 0, "first", CanvasTextStyle::default());
+        canvas
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 1, "second", CanvasTextStyle::default());
+
+        let vt = render_canvas_to_vt(&canvas, 10, 5);
+
+        assert_eq!(vt.line(0).text(), "first     ");
+        assert_eq!(vt.line(1).text(), "second    ");
+        assert_eq!(vt.cursor().row, 1, "cursor stays on last content row");
+
+        // clear and rerender
+        let mut canvas2 = Canvas::new(10, 2);
+        canvas2
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 0, "third", CanvasTextStyle::default());
+        canvas2
+            .subview_mut(0, 0, 0, 0, 10, 2)
+            .set_text(0, 1, "fourth", CanvasTextStyle::default());
+
+        let vt = render_canvases_to_vt(&[&canvas, &canvas2], 10, 5);
+
+        assert_eq!(vt.line(0).text(), "third     ");
+        assert_eq!(vt.line(1).text(), "fourth    ");
+        assert_eq!(vt.cursor().row, 1);
     }
 }


### PR DESCRIPTION
Inline mode used `canvas.write_ansi()` which appends a final `\r\n`, placing the cursor on a blank line below the rendered content. This caused a visible extra blank line during the render loop.

Switch both inline and fullscreen modes to use
`write_ansi_without_final_newline`, unifying the behavior. Simplify `clear_canvas` rewind to always use `height - 1` since neither mode emits a trailing newline now. Emit `\r\n` in `Drop` for inline mode so the shell prompt appears on a new line after the render loop exits.

## What It Does

In inline render loop there's no more empty newline emitted.
