### PR TITLE
fix: clean visible terminal in addition to scrollback to avoid artifacts

### DIFF
--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -186,6 +186,7 @@ impl TerminalImpl for StdTerminal {
                     // See: https://github.com/ccbrown/iocraft/issues/118
                     return queue!(
                         self.dest,
+                        terminal::Clear(terminal::ClearType::All),
                         terminal::Clear(terminal::ClearType::Purge),
                         cursor::MoveTo(0, 0),
                     );


### PR DESCRIPTION
## What It Does

`ClearType::Purge` only clears the scrollback and not the visible area. To clear the visible area, we need to add `ClearType::All`. If we don't add this, there are situations where we might leave artifacts, such as...

```diff
diff --git a/examples/use_output.rs b/examples/use_output.rs
index 4a968e7..90b77db 100644
--- a/examples/use_output.rs
+++ b/examples/use_output.rs
@@ -10,16 +10,45 @@ fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         stderr.println("  And hello to stderr too!");
 
         stdout.print("Working...");
-        for _ in 0..5 {
+        for i in 0..20 {
             smol::Timer::after(Duration::from_secs(1)).await;
-            stdout.print(".");
+            stdout.println(format!("{}", i));
+            stdout.println(".a");
+            stdout.println(".a");
+            stdout.println(".a");
+            stdout.println(".a");
         }
         stdout.println("\nDone!");
     });
 
     element! {
-        View(border_style: BorderStyle::Round, border_color: Color::Green) {
-            Text(content: "Hello, use_output!")
+        View(border_style: BorderStyle::Round, border_color: Color::Green, flex_direction: FlexDirection::Column) {
+            Text(content: "Hello, Ase_output!")
+            Text(content: "Hello, Bse_output!")
+            Text(content: "Hello, Cse_output!")
+            Text(content: "Hello, Dse_output!")
+            Text(content: "Hello, Ese_output!")
+            Text(content: "Hello, Fse_output!")
+            Text(content: "Hello, Gse_output!")
+            Text(content: "Hello, Hse_output!")
+            Text(content: "Hello, Ise_output!")
+            Text(content: "Hello, Jse_output!")
+            Text(content: "Hello, Kse_output!")
+            Text(content: "Hello, Lse_output!")
+            Text(content: "Hello, Mse_output!")
+            Text(content: "Hello, Nse_output!")
+            Text(content: "Hello, Ose_output!")
+            Text(content: "Hello, Pse_output!")
+            Text(content: "Hello, Qse_output!")
+            Text(content: "Hello, Rse_output!")
+            Text(content: "Hello, Sse_output!")
+            Text(content: "Hello, Tse_output!")
+            Text(content: "Hello, Use_output!")
+            Text(content: "Hello, Vse_output!")
+            Text(content: "Hello, Wse_output!")
+            Text(content: "Hello, Xse_output!")
+            Text(content: "Hello, Yse_output!")
+            Text(content: "Hello, Zse_output!")
         }
     }
 }
```

<img width="909" height="780" alt="スクリーンショット 2026-02-17 14 21 27" src="https://github.com/user-attachments/assets/84b9de65-a3f7-4788-8a8c-473fee45622f" />

I had mistakenly assumed in the past that `Purge` would clear the visible area too, based on the crossterm docs which state "All plus history". After this fix, the visible area is properly cleared and no artifacts are left behind.

## Related Issues

<!-- Please add links to any related issues here. -->
