### PR TITLE
feat: strip ANSI escape codes for text element

### DIFF
--- a/packages/iocraft/Cargo.toml
+++ b/packages/iocraft/Cargo.toml
@@ -14,6 +14,7 @@ iocraft-macros = { version = "0.2.3", path = "../iocraft-macros" }
 bitflags = "2.6.0"
 unicode-width = "0.1.13"
 generational-box = "0.5.6"
+regex = "1.12.3"
 
 [dev-dependencies]
 avt = "0.17"

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -1,6 +1,7 @@
 use crate::{
     render::MeasureFunc, segmented_string::SegmentedString, CanvasTextStyle, Color, Component,
     ComponentDrawer, ComponentUpdater, Hooks, Props, Weight,
+    strip_ansi::strip_ansi,
 };
 use taffy::{AvailableSpace, Size};
 use unicode_width::UnicodeWidthStr;
@@ -227,7 +228,7 @@ impl Component for Text {
             underline: props.decoration == TextDecoration::Underline,
             italic: props.italic,
         };
-        self.content = props.content.clone();
+        self.content = strip_ansi(&props.content);
         self.wrap = props.wrap;
         self.align = props.align;
         updater.set_measure_func(Self::measure_func(self.content.clone(), props.wrap));

--- a/packages/iocraft/src/lib.rs
+++ b/packages/iocraft/src/lib.rs
@@ -107,6 +107,7 @@ pub(crate) mod segmented_string;
 mod style;
 mod terminal;
 pub(crate) mod unicode_linebreak;
+mod strip_ansi;
 
 mod flattened_exports {
     pub use crate::canvas::*;

--- a/packages/iocraft/src/strip_ansi.rs
+++ b/packages/iocraft/src/strip_ansi.rs
@@ -1,0 +1,33 @@
+use std::sync::LazyLock;
+use regex::Regex;
+
+pub const ANSI_REGEX_PATTERN: &str = concat!(
+    // OSC branch
+    "(?:\\x1B\\][^\\x07\\x1B\\x9C]*?(?:\\x07|\\x1B\\\\|\\x9C))",
+    "|",
+    // CSI ESC[ ...
+    "(?:\\x1B\\[[\\[\\]()#;?]*(?:[0-9]{1,4}(?:[;:][0-9]{0,4})*)?[0-9A-PR-TZcf-nq-uy=><~])",
+    "|",
+    // CSI single-byte 0x9B ...
+    "(?:\\x9B[\\[\\]()#;?]*(?:[0-9]{1,4}(?:[;:][0-9]{0,4})*)?[0-9A-PR-TZcf-nq-uy=><~])",
+    "|",
+    // VT52 / short escapes (single final)
+    // Added E (NEL), M (RI), c (reset), m (SGR reset), plus existing cursor & mode keys.
+    "(?:\\x1B[ABCDHIKJSTZ=><sum78EMcNO])",
+    "|",
+    // Charset selection ESC (X or )X where X in A B 0 1 2
+    "(?:\\x1B[()][AB012])",
+    "|",
+    // Hash sequences ESC # 3 4 5 6 8
+    "(?:\\x1B#[34568])",
+    "|",
+    // Device status reports / queries: ESC [ 5 n etc (already covered by CSI) but bare 'ESC 5 n' appears in fixtures => add generic ESC [0-9]+[n] pattern fallback
+    "(?:\\x1B[0-9]+n)"
+);
+
+static ANSI_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(ANSI_REGEX_PATTERN).expect("valid ANSI regex"));
+
+pub(crate) fn strip_ansi(string: &str) -> String {
+    ANSI_REGEX.replace_all(string, "").to_string()
+}


### PR DESCRIPTION
## What It Does

Remove ANSI escape codes for Text element. A major drawback is that this pulls in regex dependency 

## Related Issues

https://github.com/ccbrown/iocraft/issues/168