### PR TITLE
fix: avoid integer overflow when calculating text alignment padding

### DIFF
--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -134,8 +134,8 @@ impl Text {
     pub(crate) fn alignment_padding(line_width: usize, align: TextAlign, width: usize) -> usize {
         match align {
             TextAlign::Left => 0,
-            TextAlign::Right => width - line_width,
-            TextAlign::Center => width / 2 - line_width / 2,
+            TextAlign::Right => width - width.min(line_width),
+            TextAlign::Center => width / 2 - width.min(line_width) / 2,
         }
     }
 


### PR DESCRIPTION
When using `TextAlign::Right` or `TextAlign::Center`, if the available width is less than the text width, the padding calculation in `Text::alignment_padding()` goes negative, causing a panic.

This just clamps the subtract amount to the available width, so the result can't go below zero.

### Testing and reproduction

I don't actually know enough to know how to write a reduced test case. In my own program, it happens deep inside a set of flex views. Something like:

```rust
            View(
                flex_direction: FlexDirection::Row,
                justify_content: JustifyContent::Stretch,
                gap: 1,
            ) {
                View(
                    flex_direction: FlexDirection::Column,
                ) {
                    ...
                }
                View(
                    flex_direction: FlexDirection::Column,
                    flex_grow: 1.0,
                ) {
                    ...
                }
                View(
                    flex_direction: FlexDirection::Column,
                    min_width: 9,
                ) {
                    Text(
                        content: &props.content,
                        align: TextAlign::Center,
                        wrap: TextWrap::NoWrap
                    )
                }
                View(
                    flex_direction: FlexDirection::Column,
                ) {
                    ...
                }
            }
        }
```

As best I can tell, in the initial layout the `View` wrapping the `Text` is given the minimum width of 9, which is fine because `props.content` is a string shorter than that. At some point, there is an update and `props.content` is longer than that. The layout however is already set, so the overflow.

With this patch applied, the padding becomes 0, and the text is drawn, overflowing its bounds, but not crashing.

<details>
<summary>Panic & backtrace</summary>

```
thread 'main' (2141347) panicked at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/components/text.rs:138:34:
attempt to subtract with overflow
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/panicking.rs:175:17
   3: iocraft::components::text::Text::alignment_padding
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/components/text.rs:138:34
   4: iocraft::components::text::Text::align::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/components/text.rs:152:33
   5: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:310:21
   6: core::option::Option<T>::map
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/option.rs:1165:29
   7: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/iter/adapters/map.rs:107:26
   8: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/alloc/src/vec/spec_from_iter_nested.rs:24:41
   9: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/alloc/src/vec/spec_from_iter.rs:33:9
  10: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/alloc/src/vec/mod.rs:3801:9
  11: core::iter::traits::iterator::Iterator::collect
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/iter/traits/iterator.rs:2035:9
  12: iocraft::components::text::Text::align
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/components/text.rs:155:18
  13: <iocraft::components::text::Text as iocraft::component::Component>::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/components/text.rs:244:23
  14: <C as iocraft::component::AnyComponent>::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:123:9
  15: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:203:28
  16: iocraft::component::Components::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:252:31
  17: iocraft::render::ComponentDrawer::for_child_node_layout
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:292:9
  18: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:251:24
  19: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  20: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  21: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  22: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:249:27
  23: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  24: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  25: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  26: iocraft::component::Components::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:252:31
  27: iocraft::render::ComponentDrawer::for_child_node_layout
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:292:9
  28: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:251:24
  29: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  30: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  31: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  32: iocraft::component::Components::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:252:31
  33: iocraft::render::ComponentDrawer::for_child_node_layout
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:292:9
  34: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:251:24
  35: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  36: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  37: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  38: iocraft::component::Components::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:252:31
  39: iocraft::render::ComponentDrawer::for_child_node_layout
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:292:9
  40: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:251:24
  41: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  42: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  43: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  44: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:249:27
  45: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  46: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  47: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  48: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:249:27
  49: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  50: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  51: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  52: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:249:27
  53: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  54: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  55: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  56: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:249:27
  57: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  58: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  59: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  60: iocraft::component::Components::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:252:31
  61: iocraft::render::ComponentDrawer::for_child_node_layout
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:292:9
  62: iocraft::component::Components::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:251:24
  63: iocraft::component::InstantiatedComponent::draw::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:207:27
  64: iocraft::render::ComponentDrawer::with_clip_rect_for_children
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:306:13
  65: iocraft::component::InstantiatedComponent::draw
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/component.rs:206:16
  66: iocraft::render::Tree::render
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:456:29
  67: iocraft::render::Tree::terminal_render_loop::{{closure}}::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:470:35
  68: iocraft::terminal::Terminal::synchronized_update
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/terminal.rs:524:9
  69: iocraft::render::Tree::terminal_render_loop::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:469:18
  70: iocraft::render::terminal_render_loop::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/render.rs:515:37
  71: <iocraft::element::RenderLoopFuture<E> as core::future::future::Future>::poll
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iocraft-0.8.0/src/element.rs:521:41
  72: async_io::driver::block_on::{{closure}}
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-io-2.6.0/src/driver.rs:204:53
  73: std::thread::local::LocalKey<T>::try_with
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:513:12
  74: std::thread::local::LocalKey<T>::with
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:477:20
  75: async_io::driver::block_on
             at /home/robn/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-io-2.6.0/src/driver.rs:180:11
  76: app::main
             at ./app/src/main.rs:412:5
  77: core::ops::function::FnOnce::call_once
             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
```

</details>

### Alternative solutions

Its possible that this is papering over problem in my program. Should I have done something to force a re-layout? Though I doubt a crash is the right thing there regardless!

There's also a world where a negative padding would be nice; consider:

```
content="the quick brown fox" (line_width=19)
width=10

  Left: |the quick | (padding=0)
 Right: | brown fox| (padding=(10-19)=-9)
Center: |quick brow| (padding=((10-19)/2)=-4)
```

I don't know if that would go against the CSS idea of text alignment. It definitely would be useful for something I'm doing elsewhere though, effectively "anchoring" a very long text line to the right instead of the left. As it is, I had to write a component to get the layout width and take a substring of the content string.