### PR TITLE
fix: skip full-screen clear in fullscreen mode to prevent flicker

### DIFF
--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -198,17 +198,26 @@ impl TerminalImpl for StdTerminal<'_> {
             return Ok(());
         }
 
-        if !self.fullscreen {
-            if let Some(size) = self.size {
-                if self.prev_canvas_height >= size.1 {
-                    // We have to clear the entire terminal to avoid leaving artifacts.
-                    // See: https://github.com/ccbrown/iocraft/issues/118
-                    self.dest
-                        .queue(terminal::Clear(terminal::ClearType::All))?
-                        .queue(terminal::Clear(terminal::ClearType::Purge))?
-                        .queue(cursor::MoveTo(0, 0))?;
-                    return Ok(());
-                }
+        if self.fullscreen {
+            // In fullscreen (alternate screen) mode, just reposition the
+            // cursor to the top-left corner.  The subsequent write_canvas
+            // overwrites every row and each row emits CSI K to erase
+            // trailing content, so a full-screen ClearFromCursorDown is
+            // unnecessary.  Skipping the clear prevents visible bottom-of-
+            // screen flicker during rapid redraws.
+            self.dest.queue(cursor::MoveTo(0, 0))?;
+            return Ok(());
+        }
+
+        if let Some(size) = self.size {
+            if self.prev_canvas_height >= size.1 {
+                // We have to clear the entire terminal to avoid leaving artifacts.
+                // See: https://github.com/ccbrown/iocraft/issues/118
+                self.dest
+                    .queue(terminal::Clear(terminal::ClearType::All))?
+                    .queue(terminal::Clear(terminal::ClearType::Purge))?
+                    .queue(cursor::MoveTo(0, 0))?;
+                return Ok(());
             }
         }
 


### PR DESCRIPTION
When using `element.fullscreen()`, rapid state changes which fire TUI updates cause visible flicker at the bottom of the terminal. The flicker ranges from a few rows to more than half the screen, and always affects the bottom portion. The issue is apparent in applications with dense per-cell styling (background colors, multiple text styles per row) and complex web of UI components/elements.

Observed on Konsole 25.04.2 (Wayland). The terminal supports DEC mode 2026 (synchronized output), but the flicker occurs regardless — the volume of ANSI data between clear and rewrite appears to exceed what synchronized output can atomically batch.

Since write_canvas() overwrites every row and each row already emits CSI K (erase to end of line), the full-screen clear is redundant. Replace it with a simple cursor reposition to (0,0).

The non-fullscreen (inline) path is unchanged — it still needs the clear to handle variable-height output correctly.

## What It Does

In fullscreen mode, replace the clear with a `cursor::MoveTo(0, 0)`.

This is safe because (as already mentioned) write_canvas() overwrites every row and emits CSI K for each row, so additional clear is redundant.

## Related Issues

(possibly related) [Flickering issue](https://github.com/ccbrown/iocraft/issues/117)