### PR TITLE
feat: re-export taffy crate so users can name taffy types without a separate dependency

### DIFF
--- a/packages/iocraft/src/lib.rs
+++ b/packages/iocraft/src/lib.rs
@@ -134,6 +134,13 @@ mod flattened_exports {
 
 pub use flattened_exports::*;
 
+/// Re-exported [`taffy`] crate, which powers flexbox layout in `iocraft`.
+///
+/// This allows you to reference `taffy` types (e.g. [`taffy::Size`],
+/// [`taffy::AvailableSpace`]) in your own code without adding a separate
+/// `taffy` dependency to your `Cargo.toml`.
+pub use taffy;
+
 /// Components for crafting your UI.
 pub mod components;
 


### PR DESCRIPTION
## Background

While exploring `MeasureFunc`, I ran into the problem described in #189 — the callback signature requires `taffy::Size`, `taffy::AvailableSpace`, and `taffy::Style`, but none of those types are currently accessible through `iocraft::`. Trying to write an implementation like:

```rust
fn my_measure(
    known: taffy::Size<Option<f32>>,
    available: taffy::Size<taffy::AvailableSpace>,
    style: &taffy::Style,
) -> taffy::Size<f32> {
    ...
}
```

…forces users to add `taffy` separately to `Cargo.toml` just to name the return type, which is awkward when `iocraft` already bundles it internally.

## Change

Following the suggestion in the issue, this PR adds a single line:

```rust
pub use taffy;
```

to `packages/iocraft/src/lib.rs`. Users can now write `iocraft::taffy::Size<f32>` instead of depending on `taffy` directly.

## Testing

The change is a one-line re-export. Existing tests all pass and the `MeasureFunc` type signature is unmodified — this purely exposes what was already an internal dependency.