### PR TITLE
fix: skip full-screen clear in fullscreen mode to prevent flicker

### DIFF
--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -210,6 +210,12 @@ impl TerminalImpl for StdTerminal<'_> {
                     return Ok(());
                 }
             }
+        } else {
+            // In fullscreen mode, skip the full clear to prevent flicker.
+            // write_canvas() overwrites every row and emits CSI K for each row,
+            // so a clear is redundant and causes visible flicker on rapid updates.
+            self.dest.queue(cursor::MoveTo(0, 0))?;
+            return Ok(());
         }
 
         clear_canvas_inline(&mut *self.dest, self.prev_canvas_height)


### PR DESCRIPTION
When using `element.fullscreen()`, rapid state changes which fire TUI updates cause visible flicker at the bottom of the terminal. The flicker ranges from a few rows to more than half the screen, and always affects the bottom portion. The issue is apparent in applications with dense per-cell styling (background colors, multiple text styles per row) and complex web of UI components/elements.

Observed on Konsole 25.04.2 (Wayland). The terminal supports DEC mode 2026 (synchronized output), but the flicker occurs regardless — the volume of ANSI data between clear and rewrite appears to exceed what synchronized output can atomically batch.

Since `write_canvas()` overwrites every row and each row already emits CSI K (erase to end of line), the full-screen clear is redundant. This fix adds an explicit early-return path for fullscreen mode that only repositions the cursor to (0,0), skipping both `clear_canvas_inline` and the full terminal clear.

The non-fullscreen (inline) path is unchanged — it still needs the clear to handle variable-height output correctly.

Fixes #190