### PR TITLE
fix: correctly overflow center/right+nowrap text

### DIFF
--- a/packages/iocraft/src/components/mixed_text.rs
+++ b/packages/iocraft/src/components/mixed_text.rs
@@ -142,15 +142,23 @@ impl Component for MixedText {
             TextWrap::Wrap => width as usize,
             TextWrap::NoWrap => usize::MAX,
         });
-        let mut drawer = TextDrawer::new(drawer, self.align != TextAlign::Left);
-        for mut line in lines {
+
+        let paddings = lines
+            .iter()
+            .map(|line| Text::alignment_padding(line.width, self.align, width as _))
+            .collect::<Vec<_>>();
+        let x_offset = paddings.iter().copied().min().unwrap_or(0);
+
+        let mut drawer = TextDrawer::new(drawer, x_offset, self.align != TextAlign::Left);
+        for (mut line, padding) in lines.into_iter().zip(paddings) {
             if self.wrap == TextWrap::Wrap {
                 line.trim_end();
             }
-            let padding = Text::alignment_padding(line.width, self.align, width as _);
-            if padding > 0 {
+
+            let additional_padding = padding - x_offset;
+            if additional_padding > 0 {
                 drawer.append_lines(
-                    [format!("{:width$}", "", width = padding).as_str()],
+                    [format!("{:width$}", "", width = additional_padding as usize).as_str()],
                     CanvasTextStyle::default(),
                 );
             }

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -152,7 +152,7 @@ impl Text {
                 let x_offset = paddings.iter().copied().min().unwrap_or(0);
                 let aligned = content
                     .lines()
-                    .zip(paddings.into_iter())
+                    .zip(paddings)
                     .map(|(line, padding)| {
                         format!(
                             "{:width$}{}",

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -131,34 +131,46 @@ impl Text {
         }
     }
 
-    pub(crate) fn alignment_padding(line_width: usize, align: TextAlign, width: usize) -> usize {
+    pub(crate) fn alignment_padding(line_width: usize, align: TextAlign, width: usize) -> isize {
         match align {
             TextAlign::Left => 0,
-            TextAlign::Right => width - line_width,
-            TextAlign::Center => width / 2 - line_width / 2,
+            TextAlign::Right => width as isize - line_width as isize,
+            TextAlign::Center => width as isize / 2 - line_width as isize / 2,
         }
     }
 
-    fn align(content: String, align: TextAlign, width: usize) -> String {
+    /// Aligns the text, returning the new string and an additional common x offset to apply to all lines.
+    fn align(content: String, align: TextAlign, width: usize) -> (isize, String) {
         match align {
-            TextAlign::Left => content,
-            _ => content
-                .lines()
-                .map(|line| {
-                    format!(
-                        "{:width$}{}",
-                        "",
-                        line,
-                        width = Self::alignment_padding(line.width(), align, width)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join("\n"),
+            TextAlign::Left => (0, content),
+            _ => {
+                let paddings = content
+                    .lines()
+                    .map(|line| Self::alignment_padding(line.width(), align, width))
+                    .collect::<Vec<_>>();
+
+                let x_offset = paddings.iter().copied().min().unwrap_or(0);
+                let aligned = content
+                    .lines()
+                    .zip(paddings.into_iter())
+                    .map(|(line, padding)| {
+                        format!(
+                            "{:width$}{}",
+                            "",
+                            line,
+                            width = (padding - x_offset) as usize
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (x_offset, aligned)
+            }
         }
     }
 }
 
 pub(crate) struct TextDrawer<'a, 'b> {
+    x_offset: isize,
     x: isize,
     y: isize,
     drawer: &'a mut ComponentDrawer<'b>,
@@ -167,9 +179,14 @@ pub(crate) struct TextDrawer<'a, 'b> {
 }
 
 impl<'a, 'b> TextDrawer<'a, 'b> {
-    pub fn new(drawer: &'a mut ComponentDrawer<'b>, skip_leading_whitespace: bool) -> Self {
+    pub fn new(
+        drawer: &'a mut ComponentDrawer<'b>,
+        x_offset: isize,
+        skip_leading_whitespace: bool,
+    ) -> Self {
         TextDrawer {
-            x: 0,
+            x_offset,
+            x: x_offset,
             y: 0,
             drawer,
             line_encountered_non_whitespace: false,
@@ -199,7 +216,7 @@ impl<'a, 'b> TextDrawer<'a, 'b> {
             self.drawer.canvas().set_text(self.x, self.y, line, style);
             if lines.peek().is_some() {
                 self.y += 1;
-                self.x = 0;
+                self.x = self.x_offset;
                 self.line_encountered_non_whitespace = false;
             } else {
                 self.x += line.width() as isize;
@@ -241,8 +258,8 @@ impl Component for Text {
             None,
             AvailableSpace::Definite(width),
         );
-        let content = Self::align(content, self.align, width as _);
-        let mut drawer = TextDrawer::new(drawer, self.align != TextAlign::Left);
+        let (x_offset, content) = Self::align(content, self.align, width as _);
+        let mut drawer = TextDrawer::new(drawer, x_offset, self.align != TextAlign::Left);
         drawer.append_lines(content.lines(), self.style);
     }
 }
@@ -346,6 +363,80 @@ mod tests {
         assert_eq!(
             element!(Text(content: "no ansi here")).to_string(),
             "no ansi here\n"
+        );
+    }
+
+    #[test]
+    fn test_alignment_no_wrap_overflow() {
+        assert_eq!(
+            element! {
+                View(
+                    flex_direction: FlexDirection::Column,
+                    width: 9,
+                ) {
+                    Text(
+                        content: "123456789abcdef",
+                        align: TextAlign::Left,
+                        wrap: TextWrap::NoWrap
+                    )
+                }
+            }
+            .to_string(),
+            "123456789\n"
+        );
+
+        assert_eq!(
+            element! {
+                View(
+                    flex_direction: FlexDirection::Column,
+                    width: 9,
+                ) {
+                    Text(
+                        content: "123456789abcdef",
+                        align: TextAlign::Center,
+                        wrap: TextWrap::NoWrap
+                    )
+                }
+            }
+            .to_string(),
+            "456789abc\n"
+        );
+
+        // If we expand the outer view, we should be able to see some of the overflowing text.
+        assert_eq!(
+            element! {
+                View(width: 20, padding_left: 2) {
+                    View(
+                        flex_direction: FlexDirection::Column,
+                        width: 9,
+                    ) {
+                        Text(
+                            content: "123456789abcdef",
+                            align: TextAlign::Center,
+                            wrap: TextWrap::NoWrap
+                        )
+                    }
+                }
+            }
+            .to_string(),
+            "23456789abcdef\n"
+        );
+
+        assert_eq!(
+            element! {
+                View(
+                    flex_direction: FlexDirection::Column,
+                    width: 9,
+                ) {
+                    Text(
+                        content: "123456789abcdef",
+                        align: TextAlign::Right,
+                        wrap: TextWrap::NoWrap
+                    )
+                }
+            }
+            .to_string(),
+            "789abcdef\n"
         );
     }
 }

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -402,6 +402,23 @@ mod tests {
             "456789abc\n"
         );
 
+        assert_eq!(
+            element! {
+                View(
+                    flex_direction: FlexDirection::Column,
+                    width: 9,
+                ) {
+                    Text(
+                        content: "123456789abcdef\n1",
+                        align: TextAlign::Center,
+                        wrap: TextWrap::NoWrap
+                    )
+                }
+            }
+            .to_string(),
+            "456789abc\n    1\n"
+        );
+
         // If we expand the outer view, we should be able to see some of the overflowing text.
         assert_eq!(
             element! {

--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -286,7 +286,7 @@ impl Component for TextBufferView {
     }
 
     fn draw(&mut self, drawer: &mut ComponentDrawer<'_>) {
-        let mut drawer = TextDrawer::new(drawer, false);
+        let mut drawer = TextDrawer::new(drawer, 0, false);
         drawer.append_lines(self.buffer.lines(), self.text_style);
     }
 }


### PR DESCRIPTION
## What It Does

This fixes the issue raised in https://github.com/ccbrown/iocraft/pull/188.

Previously, if center or right aligned non-wrapping text was placed in a view with a constrained width, we would encounter a panic:

```rs
element! {
    View(
        flex_direction: FlexDirection::Column,
        width: 9,
    ) {
        Text(
            content: "123123123123",
            align: TextAlign::Center,
            wrap: TextWrap::NoWrap
        )
    }
}
.print();
```

This PR corrects the issue, allowing the text to correctly spill over to the left and/or the right as needed, while keeping it aligned to the correct point.

## Related Issues

- #188 