### PR TITLE
feat: add inverted text style

### DIFF
--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -286,7 +286,7 @@ impl Canvas {
                         if !c.style.invert && text_style.invert {
                             needs_reset = true;
                         }
-                    } else if text_style.underline || text_style.italic || text_style.invert {
+                    } else if text_style.underline || text_style.invert {
                         needs_reset = true;
                     }
                     if needs_reset {

--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -69,6 +69,9 @@ pub struct CanvasTextStyle {
 
     /// Whether the text is italicized.
     pub italic: bool,
+
+    /// Whether the foreground and background colors should be inverted.
+    pub invert: bool,
 }
 
 /// A single cell on a [`Canvas`], containing optional text and background color.
@@ -280,7 +283,10 @@ impl Canvas {
                         if !c.style.italic && text_style.italic {
                             needs_reset = true;
                         }
-                    } else if text_style.underline {
+                        if !c.style.invert && text_style.invert {
+                            needs_reset = true;
+                        }
+                    } else if text_style.underline || text_style.italic || text_style.invert {
                         needs_reset = true;
                     }
                     if needs_reset {
@@ -312,6 +318,10 @@ impl Canvas {
 
                         if c.style.italic && !text_style.italic {
                             write!(w, csi!("{}m"), Attribute::Italic.sgr())?;
+                        }
+
+                        if c.style.invert && !text_style.invert {
+                            write!(w, csi!("{}m"), Attribute::Reverse.sgr())?;
                         }
 
                         text_style = c.style;
@@ -754,6 +764,25 @@ mod tests {
                 ..Default::default()
             },
         );
+        canvas.subview_mut(7, 0, 7, 0, 1, 1).set_text(
+            0,
+            0,
+            ".",
+            CanvasTextStyle {
+                color: Some(Color::Green),
+                invert: true,
+                ..Default::default()
+            },
+        );
+        canvas.subview_mut(8, 0, 8, 0, 1, 1).set_text(
+            0,
+            0,
+            ".",
+            CanvasTextStyle {
+                color: Some(Color::Green),
+                ..Default::default()
+            },
+        );
 
         let mut actual = Vec::new();
         canvas.write_ansi(&mut actual).unwrap();
@@ -785,6 +814,18 @@ mod tests {
         write!(expected, csi!("{}m"), Colored::ForegroundColor(Color::Red)).unwrap();
         write!(expected, ".").unwrap();
 
+        write!(
+            expected,
+            csi!("{}m"),
+            Colored::ForegroundColor(Color::Green)
+        )
+        .unwrap();
+        write!(expected, ".").unwrap();
+
+        write!(expected, csi!("{}m"), Attribute::Reverse.sgr()).unwrap();
+        write!(expected, ".").unwrap();
+
+        write!(expected, csi!("0m")).unwrap();
         write!(
             expected,
             csi!("{}m"),
@@ -933,6 +974,7 @@ line two
         let mut canvas = Canvas::new(10, 1);
         let style = CanvasTextStyle {
             weight: Weight::Bold,
+            invert: true,
             ..Default::default()
         };
         canvas
@@ -941,6 +983,7 @@ line two
         let cell = canvas.cell(0, 0).unwrap();
         let ts = cell.text_style().unwrap();
         assert_eq!(ts.weight, Weight::Bold);
+        assert!(ts.invert);
         // Empty cell returns None.
         assert!(canvas.cell(5, 0).unwrap().text_style().is_none());
     }

--- a/packages/iocraft/src/components/mixed_text.rs
+++ b/packages/iocraft/src/components/mixed_text.rs
@@ -23,6 +23,9 @@ pub struct MixedTextContent {
 
     /// Whether to italicize the text.
     pub italic: bool,
+
+    /// Whether to invert the text's foreground and background colors.
+    pub invert: bool,
 }
 
 impl MixedTextContent {
@@ -55,6 +58,12 @@ impl MixedTextContent {
     /// Returns a new [`MixedTextContent`] with italic text.
     pub fn italic(mut self) -> Self {
         self.italic = true;
+        self
+    }
+
+    /// Returns a new [`MixedTextContent`] with inverted foreground and background colors.
+    pub fn invert(mut self) -> Self {
+        self.invert = true;
         self
     }
 }
@@ -170,6 +179,7 @@ impl Component for MixedText {
                     weight: content.weight,
                     underline: content.decoration == TextDecoration::Underline,
                     italic: content.italic,
+                    invert: content.invert,
                 };
                 if segments.peek().is_some() {
                     drawer.append_lines([segment.text], style);
@@ -201,6 +211,17 @@ mod tests {
             .to_string(),
             "this is a\nwrapping test\n"
         );
+    }
+
+    #[test]
+    fn test_mixed_text_invert() {
+        let canvas = element! {
+            MixedText(contents: vec![
+                MixedTextContent::new("foo").invert(),
+            ])
+        }
+        .render(None);
+        assert!(canvas.cell(0, 0).unwrap().text_style().unwrap().invert);
     }
 
     #[test]

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -61,6 +61,9 @@ pub struct TextProps {
 
     /// Whether to italicize the text.
     pub italic: bool,
+
+    /// Whether to invert the text's foreground and background colors.
+    pub invert: bool,
 }
 
 /// `Text` is a component that renders a text string.
@@ -243,6 +246,7 @@ impl Component for Text {
             weight: props.weight,
             underline: props.decoration == TextDecoration::Underline,
             italic: props.italic,
+            invert: props.invert,
         };
         self.content = strip_ansi(&props.content).into_owned();
         self.wrap = props.wrap;
@@ -364,6 +368,12 @@ mod tests {
             element!(Text(content: "no ansi here")).to_string(),
             "no ansi here\n"
         );
+    }
+
+    #[test]
+    fn test_text_invert() {
+        let canvas = element!(Text(content: "foo", invert: true)).render(None);
+        assert!(canvas.cell(0, 0).unwrap().text_style().unwrap().invert);
     }
 
     #[test]


### PR DESCRIPTION
## What It Does

Adds support for inverted text styling, backed by crossterm's reverse video attribute.

This adds an `invert` flag to `CanvasTextStyle`, exposes the same option on `Text`, and adds an `invert()` builder method for `MixedTextContent`. ANSI rendering now emits `Attribute::Reverse` when inverted text begins and resets when it ends.

Focused tests cover ANSI output, direct canvas cell style access, `Text`, and `MixedText`.

## Related Issues

Fixes #108