### PR TITLE
fix(examples): reset cursor on ctrl+c in counter example

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -5,6 +5,10 @@ use std::time::Duration;
 fn Counter(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut count = hooks.use_state(|| 0);
 
+    // Put the terminal into raw mode so ctrl+c is delivered as a key event
+    // and iocraft can run its drop handlers to restore the cursor on exit.
+    hooks.use_terminal_events(|_| {});
+
     hooks.use_future(async move {
         loop {
             smol::Timer::after(Duration::from_millis(100)).await;


### PR DESCRIPTION
## What It Does

Adds the maintainer's option-1 fix from #197 to `examples/counter.rs`: a single `hooks.use_terminal_events(|_| {})` call (with a comment explaining why) that puts the terminal in raw mode so ctrl+c is delivered as a key event instead of a SIGINT. With raw mode active, the existing `ignore_ctrl_c` path in `packages/iocraft/src/element.rs:514` exits the render loop cleanly and runs drop handlers, which restores the cursor. Every other interactive example already does this (`use_input.rs:15`, `weather.rs:222`, `fullscreen.rs:19`, `scrolling.rs:14`, `form.rs:58`, `calculator.rs:261`); the counter example was the outlier.

This is intentionally the smallest possible change. The library itself is untouched and no new dependencies are added, matching the maintainer's note that iocraft should not set a global signal handler. If you'd rather close this in favor of a documentation-only approach (the second half of your suggestion), this PR can be discarded without churn.

## Related Issues

Closes #197

This contribution was developed with AI assistance (Codex).
