### PR TITLE
Set all `*.rs` files to Rust for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs linguist-language=Rust


### PR DESCRIPTION
## What It Does

This fixes the language bar on GitHub reporting that this project has RenderScript code, and also provides syntax highlighting for `packages/iocraft/src/unicode_linebreaki/tables.rs` GitHub.

## Related Issues

N/A

---

Additionally, you may want to set the `linguist-vendored` attribute on everything under `unicode_linebreak/`, if you feel that these files shouldn't be included in your language statistics.
