### PR TITLE
fix(use_output): corruption during async delays and stderr.print() no…

### DIFF
--- a/examples/use_output.rs
+++ b/examples/use_output.rs
@@ -4,19 +4,25 @@ use std::time::Duration;
 #[component]
 fn Example(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let (stdout, stderr) = hooks.use_output();
+    let mut system = hooks.use_context_mut::<SystemContext>();
+    let mut should_exit = hooks.use_state(|| false);
 
     hooks.use_future(async move {
         stdout.println("Hello from iocraft to stdout!");
         stderr.println("  And hello to stderr too!");
 
         stdout.print("Working...");
-        for _ in 0..5 {
-            smol::Timer::after(Duration::from_secs(1)).await;
+        for _ in 0..10 {
+            smol::Timer::after(Duration::from_millis(500)).await;
             stdout.print(".");
         }
         stdout.println("\nDone!");
+        should_exit.set(true);
     });
 
+    if *should_exit.read() {
+        system.exit();
+    }
     element! {
         View(border_style: BorderStyle::Round, border_color: Color::Green) {
             Text(content: "Hello, use_output!")

--- a/packages/iocraft/src/hooks/use_output.rs
+++ b/packages/iocraft/src/hooks/use_output.rs
@@ -133,6 +133,12 @@ impl UseOutputState {
         }
 
         if needs_extra_newline {
+            // Flush stdout and stderr so the terminal processes all written bytes
+            // before we query the cursor position. Without this, the cursor position
+            // would reflect the state before the no-newline message was rendered,
+            // causing subsequent appended output to be placed at the wrong column.
+            let _ = terminal.stdout().flush();
+            let _ = terminal.stderr().flush();
             if let Ok(pos) = cursor::position() {
                 self.appended_newline = Some(pos.0);
                 let newline = if needs_carriage_returns { "\r\n" } else { "\n" };


### PR DESCRIPTION
fix #204 