### PR TITLE
feat(TextInput): add weight/underline/italic/invert style props

### DIFF
--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -1,6 +1,6 @@
 use crate::{
     component,
-    components::{TextDrawer, TextWrap, View},
+    components::{TextDecoration, TextDrawer, TextWrap, View},
     element,
     hooks::{Ref, State, UseMemo, UseState, UseTerminalEvents},
     segmented_string::SegmentedString,
@@ -83,8 +83,8 @@ pub struct TextInputProps {
     /// The weight (boldness) of the text.
     pub weight: Weight,
 
-    /// Whether the text is underlined.
-    pub underline: bool,
+    /// The text decoration.
+    pub decoration: TextDecoration,
 
     /// Whether the text is italicized.
     pub italic: bool,
@@ -566,7 +566,7 @@ pub fn TextInput(mut hooks: Hooks, props: &mut TextInputProps) -> impl Into<AnyE
                     buffer,
                     color: props.color,
                     weight: props.weight,
-                    underline: props.underline,
+                    underline: props.decoration == TextDecoration::Underline,
                     italic: props.italic,
                     invert: props.invert,
                 )

--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -83,6 +83,15 @@ pub struct TextInputProps {
     /// The weight (boldness) of the text.
     pub weight: Weight,
 
+    /// Whether the text is underlined.
+    pub underline: bool,
+
+    /// Whether the text is italicized.
+    pub italic: bool,
+
+    /// Whether the foreground and background colors are inverted.
+    pub invert: bool,
+
     /// The current value.
     pub value: String,
 
@@ -251,6 +260,9 @@ impl TextBuffer {
 struct TextBufferViewProps {
     color: Option<Color>,
     weight: Weight,
+    underline: bool,
+    italic: bool,
+    invert: bool,
     buffer: Arc<TextBuffer>,
 }
 
@@ -276,7 +288,9 @@ impl Component for TextBufferView {
         self.text_style = CanvasTextStyle {
             color: props.color,
             weight: props.weight,
-            ..Default::default()
+            underline: props.underline,
+            italic: props.italic,
+            invert: props.invert,
         };
         self.buffer = props.buffer.clone();
         updater.set_layout_style(
@@ -552,6 +566,9 @@ pub fn TextInput(mut hooks: Hooks, props: &mut TextInputProps) -> impl Into<AnyE
                     buffer,
                     color: props.color,
                     weight: props.weight,
+                    underline: props.underline,
+                    italic: props.italic,
+                    invert: props.invert,
                 )
             }
         }

--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -6,7 +6,7 @@ use crate::{
     segmented_string::SegmentedString,
     AnyElement, CanvasTextStyle, Color, Component, ComponentDrawer, ComponentUpdater, HandlerMut,
     Hook, Hooks, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, LayoutStyle, Overflow, Position,
-    Props, Size, TerminalEvent,
+    Props, Size, TerminalEvent, Weight,
 };
 use std::sync::Arc;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -79,6 +79,9 @@ impl TextInputHandle {
 pub struct TextInputProps {
     /// The color to make the text.
     pub color: Option<Color>,
+
+    /// The weight (boldness) of the text.
+    pub weight: Weight,
 
     /// The current value.
     pub value: String,
@@ -247,6 +250,7 @@ impl TextBuffer {
 #[derive(Default, Props)]
 struct TextBufferViewProps {
     color: Option<Color>,
+    weight: Weight,
     buffer: Arc<TextBuffer>,
 }
 
@@ -271,6 +275,7 @@ impl Component for TextBufferView {
     ) {
         self.text_style = CanvasTextStyle {
             color: props.color,
+            weight: props.weight,
             ..Default::default()
         };
         self.buffer = props.buffer.clone();
@@ -546,6 +551,7 @@ pub fn TextInput(mut hooks: Hooks, props: &mut TextInputProps) -> impl Into<AnyE
                 TextBufferView(
                     buffer,
                     color: props.color,
+                    weight: props.weight,
                 )
             }
         }


### PR DESCRIPTION
I needed `weight` (to render bold input text) and rounded out the rest of the text styling while I was at it.

## What It Does

Exposes the per-cell text style on `TextInput`, matching what `Text` already offers. `TextInput`'s renderer (`TextBufferView`) built its `CanvasTextStyle` with only `color` set, leaving the other fields at default — so input text could never be bold, italic, underlined, or inverted. This adds `weight`, `underline`, `italic`, and `invert` props and threads them through to the style. All default to off, so existing behavior is unchanged.

## Related Issues

None.