### PR TITLE
refactor(terminal)!: add TerminalBackend trait, decouple from crossterm

### DIFF
--- a/packages/iocraft/CHANGELOG.md
+++ b/packages/iocraft/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add a `TerminalBackend` trait decoupling the renderer from crossterm, gated behind the new (default-on) `crossterm` feature.
+
+### Changed
+
+- `Color`, `KeyCode`, `KeyModifiers`, `KeyEventKind`, `MouseEventKind`, and `MouseButton` are now iocraft-owned types (in `crate::color`/`crate::event`) re-exported from the crate root, rather than re-exports of the crossterm types. `From` conversions to/from the crossterm equivalents are provided when the `crossterm` feature is enabled. Code that fed these directly into crossterm APIs now needs an explicit `.into()`.
+- `ElementExt::write_to_raw_fd` now takes `F: AsFd` instead of `F: AsRawFd`.
+
+### Removed
+
+- `KeyEventState` is no longer re-exported. iocraft's `KeyEvent` never carried a `state` field, so the type was unused; import it from `crossterm` directly if needed.
+
 ## [0.8.3](https://github.com/ccbrown/iocraft/compare/iocraft-v0.8.2...iocraft-v0.8.3) - 2026-05-09
 
 ### Added

--- a/packages/iocraft/Cargo.toml
+++ b/packages/iocraft/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "iocraft"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Create beautifully crafted CLI programs and text output with a declarative React-like Rust API."
 repository = "https://github.com/ccbrown/iocraft"
 
 [features]
-default = []
+default = ["crossterm"]
+# Enables the built-in crossterm-backed terminal (iocraft's default backend).
+crossterm = ["dep:crossterm"]
 unstable-output-streams = []
 
 [dependencies]
-crossterm = { version = "0.29.0", features = ["event-stream"] }
+crossterm = { version = "0.29.0", features = ["event-stream"], optional = true }
 futures = "0.3.30"
 taffy = { version = "0.5.2", default-features = false, features = ["std", "flexbox", "taffy_tree"] }
 iocraft-macros = { version = "0.2.4", path = "../iocraft-macros" }

--- a/packages/iocraft/src/backend/mod.rs
+++ b/packages/iocraft/src/backend/mod.rs
@@ -1,0 +1,120 @@
+//! The [`TerminalBackend`] trait: iocraft's seam between the renderer and a
+//! concrete terminal.
+//!
+//! All terminal interaction during a render loop flows through this trait. The
+//! built-in `CrosstermBackend` renders ANSI to stdout/stderr; alternative
+//! backends (a GUI grid, a test harness, a different terminal library) can
+//! implement the same surface without pulling in crossterm.
+//!
+//! This seam is crate-internal for now; it becomes public API once there is a
+//! public entry point that accepts a custom backend.
+
+use crate::{canvas::Canvas, element::Output, terminal::TerminalEvent};
+use futures::stream::BoxStream;
+use std::{borrow::Cow, io};
+
+/// Returns the current terminal size as `(columns, rows)`, if it can be
+/// determined outside of an active render loop.
+///
+/// Backed by crossterm when the `crossterm` feature is enabled; otherwise
+/// reports the size as unavailable.
+pub(crate) fn terminal_size() -> io::Result<(u16, u16)> {
+    #[cfg(feature = "crossterm")]
+    {
+        crossterm::terminal::size()
+    }
+    #[cfg(not(feature = "crossterm"))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "terminal size is unavailable without a terminal backend",
+        ))
+    }
+}
+
+/// A single chunk of passthrough output to be emitted *above* the rendered UI
+/// via [`use_output`](crate::hooks::UseOutput).
+///
+/// The backend decides how to place this relative to the rendered canvas. ANSI
+/// backends move the cursor above the canvas, write the text, and reflow; a
+/// grid backend might insert scrollback lines. The backend also chooses the
+/// line terminator (e.g. `\r\n` in raw mode) and must translate newlines
+/// embedded in the content to it.
+// Only the crossterm backend's `print_above` reads the fields today.
+#[cfg_attr(not(feature = "crossterm"), allow(dead_code))]
+#[derive(Clone, Debug)]
+pub(crate) struct Passthrough<'a> {
+    /// Which standard stream this text should be written to.
+    pub stream: Output,
+    /// The text to write. May contain embedded newlines. When
+    /// [`newline`](Self::newline) is `false` it never ends with one:
+    /// `use_output` normalizes a trailing newline into the flag so that the
+    /// backend picks the line terminator.
+    pub content: Cow<'a, str>,
+    /// Whether to terminate the text with a newline.
+    pub newline: bool,
+}
+
+/// A rendering and input backend for iocraft's terminal render loop.
+///
+/// Implementations must be [`Send`] so the render loop can move across threads.
+/// The trait is object-safe and used as `Box<dyn TerminalBackend>`.
+///
+/// Most methods mirror a single terminal capability. Rendering is expressed in
+/// terms of [`Canvas`] rather than raw bytes, so a backend is free to diff and
+/// emit ANSI (as `CrosstermBackend` does) or to push cells directly into a
+/// grid.
+pub(crate) trait TerminalBackend: Send {
+    /// Re-samples the terminal size. Called once per frame before rendering.
+    ///
+    /// The default implementation does nothing, for backends with a fixed or
+    /// externally-driven size.
+    fn refresh_size(&mut self) {}
+
+    /// The most recently sampled size as `(columns, rows)`, or `None` if
+    /// unknown.
+    fn size(&self) -> Option<(u16, u16)> {
+        None
+    }
+
+    /// Enables or disables mouse event reporting. Idempotent.
+    ///
+    /// The default implementation is a no-op, for backends without mouse
+    /// support.
+    fn set_mouse_capture(&mut self, enabled: bool) -> io::Result<()> {
+        let _ = enabled;
+        Ok(())
+    }
+
+    /// Brackets the start of a frame so partial updates aren't shown (e.g. a
+    /// DEC 2026 synchronized update on ANSI terminals).
+    ///
+    /// Called once per frame, paired with [`end_frame`](Self::end_frame).
+    /// Backends that never tear may leave this as the default no-op.
+    fn begin_frame(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Brackets the end of a frame. See [`begin_frame`](Self::begin_frame).
+    fn end_frame(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Erases the previously rendered canvas from the display.
+    fn clear_canvas(&mut self) -> io::Result<()>;
+
+    /// Renders `canvas`, diffing against `prev` when it is supplied.
+    fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()>;
+
+    /// Emits passthrough output above the rendered canvas, preserving the UI
+    /// beneath it.
+    ///
+    /// The whole batch queued since the last call is passed at once so the
+    /// backend can sequence stdout/stderr writes and any cursor bookkeeping in
+    /// one pass.
+    fn print_above(&mut self, messages: &[Passthrough<'_>]) -> io::Result<()>;
+
+    /// Returns a stream of input events, enabling input (and, for terminal
+    /// backends, raw mode) if it isn't already.
+    fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>>;
+}

--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -1,8 +1,5 @@
+use crate::color::{csi, sgr, SgrColor};
 use crate::style::{Color, Weight};
-use crossterm::{
-    csi,
-    style::{Attribute, Colored},
-};
 use std::{
     env,
     fmt::{self, Display},
@@ -256,6 +253,8 @@ impl Canvas {
         &row[..last_non_empty.map_or(0, |i| i + 1)]
     }
 
+    // Only consumed by the crossterm backend's frame diffing today.
+    #[cfg_attr(not(feature = "crossterm"), allow(dead_code))]
     pub(crate) fn row_eq(&self, other: &Self, y: usize) -> bool {
         self.width == other.width && self.row(y) == other.row(y)
     }
@@ -306,28 +305,28 @@ impl Canvas {
                         write!(
                             w,
                             csi!("{}m"),
-                            Colored::ForegroundColor(c.style.color.unwrap_or(Color::Reset))
+                            SgrColor::Foreground(c.style.color.unwrap_or(Color::Reset))
                         )?;
                     }
 
                     if c.style.weight != text_style.weight {
                         match c.style.weight {
-                            Weight::Bold => write!(w, csi!("{}m"), Attribute::Bold.sgr())?,
+                            Weight::Bold => write!(w, csi!("{}m"), sgr::BOLD)?,
                             Weight::Normal => {}
-                            Weight::Light => write!(w, csi!("{}m"), Attribute::Dim.sgr())?,
+                            Weight::Light => write!(w, csi!("{}m"), sgr::DIM)?,
                         }
                     }
 
                     if c.style.underline && !text_style.underline {
-                        write!(w, csi!("{}m"), Attribute::Underlined.sgr())?;
+                        write!(w, csi!("{}m"), sgr::UNDERLINED)?;
                     }
 
                     if c.style.italic && !text_style.italic {
-                        write!(w, csi!("{}m"), Attribute::Italic.sgr())?;
+                        write!(w, csi!("{}m"), sgr::ITALIC)?;
                     }
 
                     if c.style.invert && !text_style.invert {
-                        write!(w, csi!("{}m"), Attribute::Reverse.sgr())?;
+                        write!(w, csi!("{}m"), sgr::REVERSE)?;
                     }
 
                     text_style = c.style;
@@ -342,7 +341,7 @@ impl Canvas {
 
             if ansi && col >= self.width {
                 if background_color.is_some() {
-                    write!(w, csi!("{}m"), Colored::BackgroundColor(Color::Reset))?;
+                    write!(w, csi!("{}m"), SgrColor::Background(Color::Reset))?;
                     background_color = None;
                 }
 
@@ -354,7 +353,7 @@ impl Canvas {
                 write!(
                     w,
                     csi!("{}m"),
-                    Colored::BackgroundColor(cell.background_color.unwrap_or(Color::Reset))
+                    SgrColor::Background(cell.background_color.unwrap_or(Color::Reset))
                 )?;
                 background_color = cell.background_color;
             }
@@ -367,7 +366,7 @@ impl Canvas {
         }
         if ansi {
             if background_color.is_some() {
-                write!(w, csi!("{}m"), Colored::BackgroundColor(Color::Reset))?;
+                write!(w, csi!("{}m"), SgrColor::Background(Color::Reset))?;
             }
             if !did_clear_line {
                 write!(w, csi!("K"))?;
@@ -383,6 +382,7 @@ impl Canvas {
     /// terminal's default state qualifies). The function leaves SGR state
     /// reset on return, so a sequence of calls — separated only by cursor
     /// movement — will each start from a clean state.
+    #[cfg_attr(not(feature = "crossterm"), allow(dead_code))]
     pub(crate) fn write_ansi_row_without_newline<W: Write>(
         &self,
         y: usize,
@@ -423,6 +423,7 @@ impl Canvas {
         self.write_impl(w, true, false)
     }
 
+    #[cfg_attr(not(feature = "crossterm"), allow(dead_code))]
     pub(crate) fn write_ansi_without_final_newline<W: Write>(&self, w: W) -> io::Result<()> {
         self.write_impl(w, true, true)
     }
@@ -604,27 +605,17 @@ mod tests {
         // row 0
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "  ").unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, "   ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("K")).unwrap();
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "\r\n").unwrap();
         // row 1
         write!(expected, "  ").unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, "   ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("K")).unwrap();
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "\r\n").unwrap();
@@ -657,65 +648,35 @@ mod tests {
 
         // line 1
         write!(expected, csi!("0m")).unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, "     ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("K")).unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, " ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "\r\n").unwrap();
 
         // line 2
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, "     ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("K")).unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, " ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "\r\n").unwrap();
 
         // line 3
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, "     ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("K")).unwrap();
-        write!(expected, csi!("{}m"), Colored::BackgroundColor(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Red)).unwrap();
         write!(expected, " ").unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::BackgroundColor(Color::Reset)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Background(Color::Reset)).unwrap();
         write!(expected, csi!("0m")).unwrap();
         write!(expected, "\r\n").unwrap();
 
@@ -818,47 +779,37 @@ mod tests {
         write!(expected, csi!("0m")).unwrap();
         write!(expected, ".").unwrap();
 
-        write!(expected, csi!("{}m"), Colored::ForegroundColor(Color::Red)).unwrap();
-        write!(expected, csi!("{}m"), Attribute::Bold.sgr()).unwrap();
-        write!(expected, csi!("{}m"), Attribute::Underlined.sgr()).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), sgr::BOLD).unwrap();
+        write!(expected, csi!("{}m"), sgr::UNDERLINED).unwrap();
         write!(expected, ".").unwrap();
 
         write!(expected, csi!("0m")).unwrap();
-        write!(expected, csi!("{}m"), Colored::ForegroundColor(Color::Red)).unwrap();
-        write!(expected, csi!("{}m"), Attribute::Bold.sgr()).unwrap();
-        write!(expected, csi!("{}m"), Attribute::Italic.sgr()).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), sgr::BOLD).unwrap();
+        write!(expected, csi!("{}m"), sgr::ITALIC).unwrap();
         write!(expected, ".").unwrap();
 
         write!(expected, csi!("0m")).unwrap();
-        write!(expected, csi!("{}m"), Colored::ForegroundColor(Color::Red)).unwrap();
-        write!(expected, csi!("{}m"), Attribute::Bold.sgr()).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Red)).unwrap();
+        write!(expected, csi!("{}m"), sgr::BOLD).unwrap();
         write!(expected, ".").unwrap();
 
-        write!(expected, csi!("{}m"), Attribute::Dim.sgr()).unwrap();
-        write!(expected, ".").unwrap();
-
-        write!(expected, csi!("0m")).unwrap();
-        write!(expected, csi!("{}m"), Colored::ForegroundColor(Color::Red)).unwrap();
-        write!(expected, ".").unwrap();
-
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::ForegroundColor(Color::Green)
-        )
-        .unwrap();
-        write!(expected, ".").unwrap();
-
-        write!(expected, csi!("{}m"), Attribute::Reverse.sgr()).unwrap();
+        write!(expected, csi!("{}m"), sgr::DIM).unwrap();
         write!(expected, ".").unwrap();
 
         write!(expected, csi!("0m")).unwrap();
-        write!(
-            expected,
-            csi!("{}m"),
-            Colored::ForegroundColor(Color::Green)
-        )
-        .unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Red)).unwrap();
+        write!(expected, ".").unwrap();
+
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Green)).unwrap();
+        write!(expected, ".").unwrap();
+
+        write!(expected, csi!("{}m"), sgr::REVERSE).unwrap();
+        write!(expected, ".").unwrap();
+
+        write!(expected, csi!("0m")).unwrap();
+        write!(expected, csi!("{}m"), SgrColor::Foreground(Color::Green)).unwrap();
         write!(expected, ".").unwrap();
 
         write!(expected, csi!("K")).unwrap();

--- a/packages/iocraft/src/color.rs
+++ b/packages/iocraft/src/color.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::sync::OnceLock;
 
 /// Builds a CSI (Control Sequence Introducer) escape string at compile time,
 /// e.g. `csi!("0m")` produces `"\x1b[0m"`. Mirrors crossterm's `csi!` so call
@@ -129,16 +130,32 @@ pub(crate) mod sgr {
     pub const REVERSE: u8 = 7;
 }
 
+/// Whether color output is disabled via the `NO_COLOR` environment variable
+/// (see <https://no-color.org/>). The variable is read once and memoized, so
+/// this stays cheap on the per-cell render path. Matches crossterm, which
+/// applies the same suppression inside `Colored`'s `Display`.
+fn color_output_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("NO_COLOR").map(|v| !v.is_empty()).unwrap_or(false))
+}
+
 /// Wraps a [`Color`] so it renders as the SGR parameters for a foreground or
 /// background color, e.g. `38;5;9` or `49`. Used with `write!` inside a
-/// `CSI … m` sequence. The encoding is identical to what crossterm emits.
+/// `CSI … m` sequence. The encoding is identical to what crossterm emits,
+/// including emitting nothing when `NO_COLOR` is set.
 pub(crate) enum SgrColor {
     Foreground(Color),
     Background(Color),
 }
 
-impl fmt::Display for SgrColor {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl SgrColor {
+    /// Writes the SGR parameters, or nothing when `disabled` is true (the
+    /// `NO_COLOR` case). Split out from [`fmt::Display`] so it can be tested
+    /// without touching the process-wide memoized flag.
+    fn write_params(&self, f: &mut impl fmt::Write, disabled: bool) -> fmt::Result {
+        if disabled {
+            return Ok(());
+        }
         let (color, reset, prefix) = match *self {
             SgrColor::Foreground(c) => (c, "39", "38;"),
             SgrColor::Background(c) => (c, "49", "48;"),
@@ -168,6 +185,12 @@ impl fmt::Display for SgrColor {
             Color::AnsiValue(v) => write!(f, "5;{v}"),
             Color::Reset => unreachable!("Reset returned early above"),
         }
+    }
+}
+
+impl fmt::Display for SgrColor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_params(f, color_output_disabled())
     }
 }
 
@@ -265,6 +288,27 @@ mod tests {
             SgrColor::Background(Color::Rgb { r: 4, g: 5, b: 6 }).to_string(),
             "48;2;4;5;6"
         );
+    }
+
+    #[test]
+    fn no_color_suppresses_sgr_output() {
+        // With NO_COLOR in effect, no SGR parameters are emitted (matching
+        // crossterm), so the surrounding `CSI … m` collapses to a plain reset.
+        // Without it, the normal parameters are produced.
+        for color in [Color::Red, Color::Reset, Color::Rgb { r: 1, g: 2, b: 3 }] {
+            for sgr in [SgrColor::Foreground(color), SgrColor::Background(color)] {
+                let mut disabled = String::new();
+                sgr.write_params(&mut disabled, true).unwrap();
+                assert_eq!(disabled, "", "expected no output for {color:?} when disabled");
+
+                let mut enabled = String::new();
+                sgr.write_params(&mut enabled, false).unwrap();
+                assert!(
+                    !enabled.is_empty(),
+                    "expected SGR params for {color:?} when enabled"
+                );
+            }
+        }
     }
 
     #[cfg(feature = "crossterm")]

--- a/packages/iocraft/src/color.rs
+++ b/packages/iocraft/src/color.rs
@@ -1,0 +1,314 @@
+use std::fmt;
+
+/// Builds a CSI (Control Sequence Introducer) escape string at compile time,
+/// e.g. `csi!("0m")` produces `"\x1b[0m"`. Mirrors crossterm's `csi!` so call
+/// sites read the same, without depending on crossterm.
+macro_rules! csi {
+    ($( $l:literal ),*) => { concat!("\x1b[", $( $l ),*) };
+}
+pub(crate) use csi;
+
+/// A color that can be applied to text or backgrounds.
+///
+/// The named variants map to the standard 16 terminal colors; [`Color::Rgb`]
+/// and [`Color::AnsiValue`] allow true-color and 256-color selection where the
+/// terminal supports it.
+///
+/// This mirrors the color model used by common terminal libraries, but is
+/// owned by iocraft so that rendering backends do not have to depend on any
+/// particular one. When the `crossterm` feature is enabled, `From`/`Into`
+/// conversions to and from [`crossterm::style::Color`] are provided.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Color {
+    /// Resets the color to the terminal's default.
+    Reset,
+    /// Black.
+    Black,
+    /// Dark grey.
+    DarkGrey,
+    /// Light red.
+    Red,
+    /// Dark red.
+    DarkRed,
+    /// Light green.
+    Green,
+    /// Dark green.
+    DarkGreen,
+    /// Light yellow.
+    Yellow,
+    /// Dark yellow.
+    DarkYellow,
+    /// Light blue.
+    Blue,
+    /// Dark blue.
+    DarkBlue,
+    /// Light magenta.
+    Magenta,
+    /// Dark magenta.
+    DarkMagenta,
+    /// Light cyan.
+    Cyan,
+    /// Dark cyan.
+    DarkCyan,
+    /// White.
+    White,
+    /// Grey.
+    Grey,
+    /// A 24-bit RGB color. Supported by most modern terminals.
+    Rgb {
+        /// The red channel.
+        r: u8,
+        /// The green channel.
+        g: u8,
+        /// The blue channel.
+        b: u8,
+    },
+    /// An 8-bit indexed color from the 256-color palette.
+    AnsiValue(u8),
+}
+
+impl TryFrom<&str> for Color {
+    type Error = ();
+
+    /// Tries to create a `Color` from a name like `"red"` or `"dark_grey"`
+    /// (case-insensitive), matching the names crossterm accepts. Returns an
+    /// error if the string does not match a named color.
+    fn try_from(src: &str) -> Result<Self, Self::Error> {
+        match src.to_lowercase().as_str() {
+            "reset" => Ok(Color::Reset),
+            "black" => Ok(Color::Black),
+            "dark_grey" => Ok(Color::DarkGrey),
+            "red" => Ok(Color::Red),
+            "dark_red" => Ok(Color::DarkRed),
+            "green" => Ok(Color::Green),
+            "dark_green" => Ok(Color::DarkGreen),
+            "yellow" => Ok(Color::Yellow),
+            "dark_yellow" => Ok(Color::DarkYellow),
+            "blue" => Ok(Color::Blue),
+            "dark_blue" => Ok(Color::DarkBlue),
+            "magenta" => Ok(Color::Magenta),
+            "dark_magenta" => Ok(Color::DarkMagenta),
+            "cyan" => Ok(Color::Cyan),
+            "dark_cyan" => Ok(Color::DarkCyan),
+            "white" => Ok(Color::White),
+            "grey" => Ok(Color::Grey),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::str::FromStr for Color {
+    type Err = ();
+
+    /// Creates a `Color` from a name like `"red"`. Unknown names fall back to
+    /// [`Color::White`], matching crossterm's behavior.
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        Ok(Color::try_from(src).unwrap_or(Color::White))
+    }
+}
+
+impl From<(u8, u8, u8)> for Color {
+    /// Creates a [`Color::Rgb`] from an `(r, g, b)` tuple.
+    fn from((r, g, b): (u8, u8, u8)) -> Self {
+        Color::Rgb { r, g, b }
+    }
+}
+
+/// SGR parameters for the attributes iocraft emits, matching the codes standard
+/// terminals (and crossterm) use, so canvas output stays byte-for-byte stable.
+pub(crate) mod sgr {
+    /// Bold / increased intensity.
+    pub const BOLD: u8 = 1;
+    /// Dim / decreased intensity.
+    pub const DIM: u8 = 2;
+    /// Italic.
+    pub const ITALIC: u8 = 3;
+    /// Underline.
+    pub const UNDERLINED: u8 = 4;
+    /// Reverse video (swap foreground and background).
+    pub const REVERSE: u8 = 7;
+}
+
+/// Wraps a [`Color`] so it renders as the SGR parameters for a foreground or
+/// background color, e.g. `38;5;9` or `49`. Used with `write!` inside a
+/// `CSI … m` sequence. The encoding is identical to what crossterm emits.
+pub(crate) enum SgrColor {
+    Foreground(Color),
+    Background(Color),
+}
+
+impl fmt::Display for SgrColor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (color, reset, prefix) = match *self {
+            SgrColor::Foreground(c) => (c, "39", "38;"),
+            SgrColor::Background(c) => (c, "49", "48;"),
+        };
+        if color == Color::Reset {
+            return f.write_str(reset);
+        }
+        f.write_str(prefix)?;
+        match color {
+            Color::Black => f.write_str("5;0"),
+            Color::DarkGrey => f.write_str("5;8"),
+            Color::Red => f.write_str("5;9"),
+            Color::DarkRed => f.write_str("5;1"),
+            Color::Green => f.write_str("5;10"),
+            Color::DarkGreen => f.write_str("5;2"),
+            Color::Yellow => f.write_str("5;11"),
+            Color::DarkYellow => f.write_str("5;3"),
+            Color::Blue => f.write_str("5;12"),
+            Color::DarkBlue => f.write_str("5;4"),
+            Color::Magenta => f.write_str("5;13"),
+            Color::DarkMagenta => f.write_str("5;5"),
+            Color::Cyan => f.write_str("5;14"),
+            Color::DarkCyan => f.write_str("5;6"),
+            Color::White => f.write_str("5;15"),
+            Color::Grey => f.write_str("5;7"),
+            Color::Rgb { r, g, b } => write!(f, "2;{r};{g};{b}"),
+            Color::AnsiValue(v) => write!(f, "5;{v}"),
+            Color::Reset => unreachable!("Reset returned early above"),
+        }
+    }
+}
+
+#[cfg(feature = "crossterm")]
+impl From<Color> for crossterm::style::Color {
+    fn from(c: Color) -> Self {
+        use crossterm::style::Color as Ct;
+        match c {
+            Color::Reset => Ct::Reset,
+            Color::Black => Ct::Black,
+            Color::DarkGrey => Ct::DarkGrey,
+            Color::Red => Ct::Red,
+            Color::DarkRed => Ct::DarkRed,
+            Color::Green => Ct::Green,
+            Color::DarkGreen => Ct::DarkGreen,
+            Color::Yellow => Ct::Yellow,
+            Color::DarkYellow => Ct::DarkYellow,
+            Color::Blue => Ct::Blue,
+            Color::DarkBlue => Ct::DarkBlue,
+            Color::Magenta => Ct::Magenta,
+            Color::DarkMagenta => Ct::DarkMagenta,
+            Color::Cyan => Ct::Cyan,
+            Color::DarkCyan => Ct::DarkCyan,
+            Color::White => Ct::White,
+            Color::Grey => Ct::Grey,
+            Color::Rgb { r, g, b } => Ct::Rgb { r, g, b },
+            Color::AnsiValue(v) => Ct::AnsiValue(v),
+        }
+    }
+}
+
+#[cfg(feature = "crossterm")]
+impl From<crossterm::style::Color> for Color {
+    fn from(c: crossterm::style::Color) -> Self {
+        use crossterm::style::Color as Ct;
+        match c {
+            Ct::Reset => Color::Reset,
+            Ct::Black => Color::Black,
+            Ct::DarkGrey => Color::DarkGrey,
+            Ct::Red => Color::Red,
+            Ct::DarkRed => Color::DarkRed,
+            Ct::Green => Color::Green,
+            Ct::DarkGreen => Color::DarkGreen,
+            Ct::Yellow => Color::Yellow,
+            Ct::DarkYellow => Color::DarkYellow,
+            Ct::Blue => Color::Blue,
+            Ct::DarkBlue => Color::DarkBlue,
+            Ct::Magenta => Color::Magenta,
+            Ct::DarkMagenta => Color::DarkMagenta,
+            Ct::Cyan => Color::Cyan,
+            Ct::DarkCyan => Color::DarkCyan,
+            Ct::White => Color::White,
+            Ct::Grey => Color::Grey,
+            Ct::Rgb { r, g, b } => Color::Rgb { r, g, b },
+            Ct::AnsiValue(v) => Color::AnsiValue(v),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_color_names() {
+        assert_eq!(Color::try_from("red"), Ok(Color::Red));
+        assert_eq!(Color::try_from("DARK_GREY"), Ok(Color::DarkGrey));
+        assert!(Color::try_from("not_a_color").is_err());
+        assert_eq!("dark_magenta".parse::<Color>(), Ok(Color::DarkMagenta));
+        // Unknown names fall back to white, matching crossterm.
+        assert_eq!("nope".parse::<Color>(), Ok(Color::White));
+        assert_eq!(Color::from((1, 2, 3)), Color::Rgb { r: 1, g: 2, b: 3 });
+    }
+
+    #[test]
+    fn foreground_sgr_matches_expected() {
+        assert_eq!(SgrColor::Foreground(Color::Reset).to_string(), "39");
+        assert_eq!(SgrColor::Foreground(Color::Red).to_string(), "38;5;9");
+        assert_eq!(SgrColor::Foreground(Color::Grey).to_string(), "38;5;7");
+        assert_eq!(
+            SgrColor::Foreground(Color::Rgb { r: 1, g: 2, b: 3 }).to_string(),
+            "38;2;1;2;3"
+        );
+        assert_eq!(
+            SgrColor::Foreground(Color::AnsiValue(200)).to_string(),
+            "38;5;200"
+        );
+    }
+
+    #[test]
+    fn background_sgr_matches_expected() {
+        assert_eq!(SgrColor::Background(Color::Reset).to_string(), "49");
+        assert_eq!(SgrColor::Background(Color::Red).to_string(), "48;5;9");
+        assert_eq!(
+            SgrColor::Background(Color::Rgb { r: 4, g: 5, b: 6 }).to_string(),
+            "48;2;4;5;6"
+        );
+    }
+
+    #[cfg(feature = "crossterm")]
+    #[test]
+    fn crossterm_roundtrip_and_output_parity() {
+        let colors = [
+            Color::Reset,
+            Color::Black,
+            Color::DarkGrey,
+            Color::Red,
+            Color::DarkRed,
+            Color::Green,
+            Color::DarkGreen,
+            Color::Yellow,
+            Color::DarkYellow,
+            Color::Blue,
+            Color::DarkBlue,
+            Color::Magenta,
+            Color::DarkMagenta,
+            Color::Cyan,
+            Color::DarkCyan,
+            Color::White,
+            Color::Grey,
+            Color::Rgb {
+                r: 10,
+                g: 20,
+                b: 30,
+            },
+            Color::AnsiValue(123),
+        ];
+        for c in colors {
+            let ct: crossterm::style::Color = c.into();
+            assert_eq!(Color::from(ct), c, "roundtrip failed for {c:?}");
+            // Output must match crossterm's Colored exactly.
+            assert_eq!(
+                SgrColor::Foreground(c).to_string(),
+                crossterm::style::Colored::ForegroundColor(ct).to_string(),
+                "foreground SGR mismatch for {c:?}"
+            );
+            assert_eq!(
+                SgrColor::Background(c).to_string(),
+                crossterm::style::Colored::BackgroundColor(ct).to_string(),
+                "background SGR mismatch for {c:?}"
+            );
+        }
+    }
+}

--- a/packages/iocraft/src/components/button.rs
+++ b/packages/iocraft/src/components/button.rs
@@ -71,7 +71,7 @@ pub fn Button<'a>(mut hooks: Hooks, props: &mut ButtonProps<'a>) -> impl Into<An
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use crossterm::event::MouseButton;
+    use crate::MouseButton;
     use futures::stream::StreamExt;
     use macro_rules_attribute::apply;
     use smol_macros::test;

--- a/packages/iocraft/src/components/text.rs
+++ b/packages/iocraft/src/components/text.rs
@@ -270,8 +270,8 @@ impl Component for Text {
 
 #[cfg(test)]
 mod tests {
+    use crate::color::{csi, sgr};
     use crate::prelude::*;
-    use crossterm::{csi, style::Attribute};
     use std::io::Write;
 
     #[test]
@@ -332,14 +332,14 @@ mod tests {
             // row 0
             write!(expected, csi!("0m")).unwrap();
             write!(expected, "   ").unwrap();
-            write!(expected, csi!("{}m"), Attribute::Underlined.sgr()).unwrap();
+            write!(expected, csi!("{}m"), sgr::UNDERLINED).unwrap();
             write!(expected, "this is an").unwrap();
             write!(expected, csi!("K")).unwrap();
             write!(expected, csi!("0m")).unwrap();
             write!(expected, "\r\n").unwrap();
             // row 1
             write!(expected, " ").unwrap();
-            write!(expected, csi!("{}m"), Attribute::Underlined.sgr()).unwrap();
+            write!(expected, csi!("{}m"), sgr::UNDERLINED).unwrap();
             write!(expected, "alignment test").unwrap();
             write!(expected, csi!("K")).unwrap();
             write!(expected, csi!("0m")).unwrap();

--- a/packages/iocraft/src/element.rs
+++ b/packages/iocraft/src/element.rs
@@ -153,17 +153,37 @@ mod private {
 }
 
 /// Renders `el` sized to the terminal width when `is_terminal` is true and the
-/// terminal size can be determined, writing ANSI escape codes. Otherwise writes
-/// it unstyled, without width constraints.
+/// terminal size can be determined, writing ANSI escape codes. When no terminal
+/// backend is compiled in, it is written unstyled, without width constraints. A
+/// genuine failure to query the size of a real terminal is propagated.
 fn write_sized_or_plain<E: ElementExt, W: Write>(
     el: &mut E,
     w: W,
     is_terminal: bool,
 ) -> io::Result<()> {
+    write_sized_or_plain_with(el, w, is_terminal, terminal_size)
+}
+
+/// Core of [`write_sized_or_plain`] with the size source injected, so the
+/// fallback-vs-propagate logic can be tested without a real terminal.
+fn write_sized_or_plain_with<E: ElementExt, W: Write>(
+    el: &mut E,
+    w: W,
+    is_terminal: bool,
+    size: impl FnOnce() -> io::Result<(u16, u16)>,
+) -> io::Result<()> {
     if is_terminal {
-        if let Ok((width, _)) = terminal_size() {
-            let canvas = el.render(Some(width as _));
-            return canvas.write_ansi(w);
+        match size() {
+            Ok((width, _)) => {
+                let canvas = el.render(Some(width as _));
+                return canvas.write_ansi(w);
+            }
+            // No backend is compiled in to report a size; fall back to plain,
+            // unconstrained output rather than failing.
+            Err(e) if e.kind() == io::ErrorKind::Unsupported => {}
+            // The terminal exists but its size couldn't be determined; surface
+            // it, matching the pre-backend behavior.
+            Err(e) => return Err(e),
         }
     }
     el.write(w)
@@ -209,8 +229,8 @@ pub trait ElementExt: private::Sealed + Sized {
     }
 
     /// Renders the element and writes it to the given file descriptor. If the file descriptor
-    /// is a TTY, the canvas will be rendered based on its size, with ANSI escape codes. If the
-    /// terminal size cannot be determined, the output is written unstyled, without width
+    /// is a TTY, the canvas will be rendered based on its size, with ANSI escape codes. When no
+    /// terminal backend is compiled in, the output is written unstyled, without width
     /// constraints.
     #[cfg(unix)]
     fn write_to_raw_fd<F: Write + std::os::fd::AsFd>(&mut self, fd: F) -> io::Result<()> {
@@ -220,8 +240,8 @@ pub trait ElementExt: private::Sealed + Sized {
 
     /// Renders the element and writes it to the given writer also implementing
     /// [`IsTerminal`](std::io::IsTerminal). If the writer is a terminal, the canvas will be
-    /// rendered based on its size, with ANSI escape codes. If the terminal size cannot be
-    /// determined, the output is written unstyled, without width constraints.
+    /// rendered based on its size, with ANSI escape codes. When no terminal backend is compiled
+    /// in, the output is written unstyled, without width constraints.
     fn write_to_is_terminal<W: Write + IsTerminal>(&mut self, w: W) -> io::Result<()> {
         let is_terminal = w.is_terminal();
         write_sized_or_plain(self, w, is_terminal)
@@ -659,5 +679,36 @@ mod tests {
         let mut element = element!(View);
         let render_loop_future = element.render_loop();
         assert_send(render_loop_future);
+    }
+
+    #[test]
+    fn test_write_sized_or_plain_size_error_handling() {
+        use super::write_sized_or_plain_with;
+        use std::io;
+
+        // A genuine failure to size a real terminal is propagated, rather than
+        // silently downgrading to unstyled output.
+        let mut el = element!(View);
+        let mut out = Vec::new();
+        let err = write_sized_or_plain_with(&mut el, &mut out, true, || {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "no size"))
+        })
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+
+        // When no backend can report a size (Unsupported), fall back to plain
+        // output without error.
+        let mut out = Vec::new();
+        write_sized_or_plain_with(&mut el, &mut out, true, || {
+            Err(io::Error::new(io::ErrorKind::Unsupported, "no backend"))
+        })
+        .unwrap();
+
+        // A non-terminal writer never queries the size and writes plain output.
+        let mut out = Vec::new();
+        write_sized_or_plain_with(&mut el, &mut out, false, || {
+            panic!("size must not be queried for a non-terminal")
+        })
+        .unwrap();
     }
 }

--- a/packages/iocraft/src/element.rs
+++ b/packages/iocraft/src/element.rs
@@ -1,11 +1,11 @@
 use crate::{
     any_key::AnyKey,
+    backend::terminal_size,
     component::{Component, ComponentHelper, ComponentHelperExt},
     mock_terminal_render_loop,
     props::AnyProps,
     render, terminal_render_loop, Canvas, MockTerminalConfig, Terminal,
 };
-use crossterm::terminal;
 use futures::Stream;
 use std::{
     fmt::Debug,
@@ -152,6 +152,23 @@ mod private {
     impl<T> Sealed for &mut Element<'_, T> where T: Component {}
 }
 
+/// Renders `el` sized to the terminal width when `is_terminal` is true and the
+/// terminal size can be determined, writing ANSI escape codes. Otherwise writes
+/// it unstyled, without width constraints.
+fn write_sized_or_plain<E: ElementExt, W: Write>(
+    el: &mut E,
+    w: W,
+    is_terminal: bool,
+) -> io::Result<()> {
+    if is_terminal {
+        if let Ok((width, _)) = terminal_size() {
+            let canvas = el.render(Some(width as _));
+            return canvas.write_ansi(w);
+        }
+    }
+    el.write(w)
+}
+
 /// A trait implemented by all element types, providing methods for common operations on them.
 pub trait ElementExt: private::Sealed + Sized {
     /// Returns the key of the element.
@@ -191,31 +208,23 @@ pub trait ElementExt: private::Sealed + Sized {
         canvas.write(w)
     }
 
-    /// Renders the element and writes it to the given raw file descriptor. If the file descriptor
-    /// is a TTY, the canvas will be rendered based on its size, with ANSI escape codes.
+    /// Renders the element and writes it to the given file descriptor. If the file descriptor
+    /// is a TTY, the canvas will be rendered based on its size, with ANSI escape codes. If the
+    /// terminal size cannot be determined, the output is written unstyled, without width
+    /// constraints.
     #[cfg(unix)]
-    fn write_to_raw_fd<F: Write + std::os::fd::AsRawFd>(&mut self, fd: F) -> io::Result<()> {
-        use crossterm::tty::IsTty;
-        if fd.is_tty() {
-            let (width, _) = terminal::size()?;
-            let canvas = self.render(Some(width as _));
-            canvas.write_ansi(fd)
-        } else {
-            self.write(fd)
-        }
+    fn write_to_raw_fd<F: Write + std::os::fd::AsFd>(&mut self, fd: F) -> io::Result<()> {
+        let is_terminal = fd.as_fd().is_terminal();
+        write_sized_or_plain(self, fd, is_terminal)
     }
 
     /// Renders the element and writes it to the given writer also implementing
     /// [`IsTerminal`](std::io::IsTerminal). If the writer is a terminal, the canvas will be
-    /// rendered based on its size, with ANSI escape codes.
+    /// rendered based on its size, with ANSI escape codes. If the terminal size cannot be
+    /// determined, the output is written unstyled, without width constraints.
     fn write_to_is_terminal<W: Write + IsTerminal>(&mut self, w: W) -> io::Result<()> {
-        if w.is_terminal() {
-            let (width, _) = terminal::size()?;
-            let canvas = self.render(Some(width as _));
-            canvas.write_ansi(w)
-        } else {
-            self.write(w)
-        }
+        let is_terminal = w.is_terminal();
+        write_sized_or_plain(self, w, is_terminal)
     }
 
     /// Returns a future which renders the element in a loop, allowing it to be dynamic and

--- a/packages/iocraft/src/event.rs
+++ b/packages/iocraft/src/event.rs
@@ -1,0 +1,517 @@
+//! Backend-agnostic input event types.
+//!
+//! These mirror the key and mouse model exposed by common terminal libraries,
+//! but are owned by iocraft so that rendering/input backends do not have to
+//! depend on any particular one. When the `crossterm` feature is enabled,
+//! `From` conversions from the corresponding `crossterm::event` types are
+//! provided.
+
+use bitflags::bitflags;
+use std::fmt;
+
+/// Represents a key on the keyboard.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum KeyCode {
+    /// Backspace key (Delete on macOS, Backspace on other platforms).
+    Backspace,
+    /// Enter key.
+    Enter,
+    /// Left arrow key.
+    Left,
+    /// Right arrow key.
+    Right,
+    /// Up arrow key.
+    Up,
+    /// Down arrow key.
+    Down,
+    /// Home key.
+    Home,
+    /// End key.
+    End,
+    /// Page up key.
+    PageUp,
+    /// Page down key.
+    PageDown,
+    /// Tab key.
+    Tab,
+    /// Shift + Tab key.
+    BackTab,
+    /// Delete key.
+    Delete,
+    /// Insert key.
+    Insert,
+    /// Function key, e.g. `KeyCode::F(1)` for F1.
+    F(u8),
+    /// A character key.
+    Char(char),
+    /// Null.
+    Null,
+    /// Escape key.
+    Esc,
+    /// Caps Lock key (requires keyboard enhancement).
+    CapsLock,
+    /// Scroll Lock key (requires keyboard enhancement).
+    ScrollLock,
+    /// Num Lock key (requires keyboard enhancement).
+    NumLock,
+    /// Print Screen key (requires keyboard enhancement).
+    PrintScreen,
+    /// Pause key (requires keyboard enhancement).
+    Pause,
+    /// Menu key (requires keyboard enhancement).
+    Menu,
+    /// The "Begin" key, often the keypad 5 with Num Lock on (requires keyboard enhancement).
+    KeypadBegin,
+    /// A media key (requires keyboard enhancement).
+    Media(MediaKeyCode),
+    /// A modifier key (requires keyboard enhancement).
+    Modifier(ModifierKeyCode),
+}
+
+/// Represents a media key (as part of [`KeyCode::Media`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum MediaKeyCode {
+    /// Play media key.
+    Play,
+    /// Pause media key.
+    Pause,
+    /// Play/Pause media key.
+    PlayPause,
+    /// Reverse media key.
+    Reverse,
+    /// Stop media key.
+    Stop,
+    /// Fast-forward media key.
+    FastForward,
+    /// Rewind media key.
+    Rewind,
+    /// Next-track media key.
+    TrackNext,
+    /// Previous-track media key.
+    TrackPrevious,
+    /// Record media key.
+    Record,
+    /// Lower-volume media key.
+    LowerVolume,
+    /// Raise-volume media key.
+    RaiseVolume,
+    /// Mute media key.
+    MuteVolume,
+}
+
+/// Represents a modifier key (as part of [`KeyCode::Modifier`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum ModifierKeyCode {
+    /// Left Shift key.
+    LeftShift,
+    /// Left Control key.
+    LeftControl,
+    /// Left Alt key.
+    LeftAlt,
+    /// Left Super key.
+    LeftSuper,
+    /// Left Hyper key.
+    LeftHyper,
+    /// Left Meta key.
+    LeftMeta,
+    /// Right Shift key.
+    RightShift,
+    /// Right Control key.
+    RightControl,
+    /// Right Alt key.
+    RightAlt,
+    /// Right Super key.
+    RightSuper,
+    /// Right Hyper key.
+    RightHyper,
+    /// Right Meta key.
+    RightMeta,
+    /// Iso Level3 Shift key.
+    IsoLevel3Shift,
+    /// Iso Level5 Shift key.
+    IsoLevel5Shift,
+}
+
+bitflags! {
+    /// Represents key modifiers (shift, control, alt, etc.).
+    #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+    pub struct KeyModifiers: u8 {
+        /// The shift key.
+        const SHIFT = 0b0000_0001;
+        /// The control key.
+        const CONTROL = 0b0000_0010;
+        /// The alt key.
+        const ALT = 0b0000_0100;
+        /// The super key.
+        const SUPER = 0b0000_1000;
+        /// The hyper key.
+        const HYPER = 0b0001_0000;
+        /// The meta key.
+        const META = 0b0010_0000;
+        /// No modifiers.
+        const NONE = 0b0000_0000;
+    }
+}
+
+/// Represents the kind of a key event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum KeyEventKind {
+    /// The key was pressed.
+    Press,
+    /// The key is being held down and repeating.
+    Repeat,
+    /// The key was released.
+    Release,
+}
+
+/// Represents a mouse button.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum MouseButton {
+    /// Left mouse button.
+    Left,
+    /// Right mouse button.
+    Right,
+    /// Middle mouse button.
+    Middle,
+}
+
+/// Represents the kind of a mouse event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd)]
+pub enum MouseEventKind {
+    /// A mouse button was pressed.
+    Down(MouseButton),
+    /// A mouse button was released.
+    Up(MouseButton),
+    /// The mouse was moved with a button held down.
+    Drag(MouseButton),
+    /// The mouse was moved with no button held down.
+    Moved,
+    /// The mouse wheel was scrolled down (towards the user).
+    ScrollDown,
+    /// The mouse wheel was scrolled up (away from the user).
+    ScrollUp,
+    /// The mouse wheel was scrolled left.
+    ScrollLeft,
+    /// The mouse wheel was scrolled right.
+    ScrollRight,
+}
+
+impl fmt::Display for KeyCode {
+    /// Formats the `KeyCode` using the given formatter. The output matches
+    /// crossterm's, including its platform-specific key names (e.g. the
+    /// Backspace key is displayed as "Delete" on macOS).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(target_os = "macos")]
+            KeyCode::Backspace => write!(f, "Delete"),
+            #[cfg(target_os = "macos")]
+            KeyCode::Delete => write!(f, "Fwd Del"),
+            #[cfg(not(target_os = "macos"))]
+            KeyCode::Backspace => write!(f, "Backspace"),
+            #[cfg(not(target_os = "macos"))]
+            KeyCode::Delete => write!(f, "Del"),
+            #[cfg(target_os = "macos")]
+            KeyCode::Enter => write!(f, "Return"),
+            #[cfg(not(target_os = "macos"))]
+            KeyCode::Enter => write!(f, "Enter"),
+            KeyCode::Left => write!(f, "Left"),
+            KeyCode::Right => write!(f, "Right"),
+            KeyCode::Up => write!(f, "Up"),
+            KeyCode::Down => write!(f, "Down"),
+            KeyCode::Home => write!(f, "Home"),
+            KeyCode::End => write!(f, "End"),
+            KeyCode::PageUp => write!(f, "Page Up"),
+            KeyCode::PageDown => write!(f, "Page Down"),
+            KeyCode::Tab => write!(f, "Tab"),
+            KeyCode::BackTab => write!(f, "Back Tab"),
+            KeyCode::Insert => write!(f, "Insert"),
+            KeyCode::F(n) => write!(f, "F{}", n),
+            KeyCode::Char(c) => match c {
+                // special case for non-visible characters
+                ' ' => write!(f, "Space"),
+                c => write!(f, "{}", c),
+            },
+            KeyCode::Null => write!(f, "Null"),
+            KeyCode::Esc => write!(f, "Esc"),
+            KeyCode::CapsLock => write!(f, "Caps Lock"),
+            KeyCode::ScrollLock => write!(f, "Scroll Lock"),
+            KeyCode::NumLock => write!(f, "Num Lock"),
+            KeyCode::PrintScreen => write!(f, "Print Screen"),
+            KeyCode::Pause => write!(f, "Pause"),
+            KeyCode::Menu => write!(f, "Menu"),
+            KeyCode::KeypadBegin => write!(f, "Begin"),
+            KeyCode::Media(media) => write!(f, "{}", media),
+            KeyCode::Modifier(modifier) => write!(f, "{}", modifier),
+        }
+    }
+}
+
+impl fmt::Display for KeyModifiers {
+    /// Formats the key modifiers joined by a `+` character, matching
+    /// crossterm's output, including its platform-specific modifier names
+    /// (e.g. the super key is displayed as "Command" on macOS).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for modifier in self.iter() {
+            if !first {
+                f.write_str("+")?;
+            }
+            first = false;
+            match modifier {
+                KeyModifiers::SHIFT => f.write_str("Shift")?,
+                #[cfg(unix)]
+                KeyModifiers::CONTROL => f.write_str("Control")?,
+                #[cfg(windows)]
+                KeyModifiers::CONTROL => f.write_str("Ctrl")?,
+                #[cfg(target_os = "macos")]
+                KeyModifiers::ALT => f.write_str("Option")?,
+                #[cfg(not(target_os = "macos"))]
+                KeyModifiers::ALT => f.write_str("Alt")?,
+                #[cfg(target_os = "macos")]
+                KeyModifiers::SUPER => f.write_str("Command")?,
+                #[cfg(target_os = "windows")]
+                KeyModifiers::SUPER => f.write_str("Windows")?,
+                #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                KeyModifiers::SUPER => f.write_str("Super")?,
+                KeyModifiers::HYPER => f.write_str("Hyper")?,
+                KeyModifiers::META => f.write_str("Meta")?,
+                _ => unreachable!(),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for MediaKeyCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MediaKeyCode::Play => write!(f, "Play"),
+            MediaKeyCode::Pause => write!(f, "Pause"),
+            MediaKeyCode::PlayPause => write!(f, "Play/Pause"),
+            MediaKeyCode::Reverse => write!(f, "Reverse"),
+            MediaKeyCode::Stop => write!(f, "Stop"),
+            MediaKeyCode::FastForward => write!(f, "Fast Forward"),
+            MediaKeyCode::Rewind => write!(f, "Rewind"),
+            MediaKeyCode::TrackNext => write!(f, "Next Track"),
+            MediaKeyCode::TrackPrevious => write!(f, "Previous Track"),
+            MediaKeyCode::Record => write!(f, "Record"),
+            MediaKeyCode::LowerVolume => write!(f, "Lower Volume"),
+            MediaKeyCode::RaiseVolume => write!(f, "Raise Volume"),
+            MediaKeyCode::MuteVolume => write!(f, "Mute Volume"),
+        }
+    }
+}
+
+impl fmt::Display for ModifierKeyCode {
+    /// Formats the modifier key using the given formatter. The output matches
+    /// crossterm's, including its platform-specific key names.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ModifierKeyCode::LeftShift => write!(f, "Left Shift"),
+            ModifierKeyCode::LeftHyper => write!(f, "Left Hyper"),
+            ModifierKeyCode::LeftMeta => write!(f, "Left Meta"),
+            ModifierKeyCode::RightShift => write!(f, "Right Shift"),
+            ModifierKeyCode::RightHyper => write!(f, "Right Hyper"),
+            ModifierKeyCode::RightMeta => write!(f, "Right Meta"),
+            ModifierKeyCode::IsoLevel3Shift => write!(f, "Iso Level 3 Shift"),
+            ModifierKeyCode::IsoLevel5Shift => write!(f, "Iso Level 5 Shift"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::LeftControl => write!(f, "Left Control"),
+            #[cfg(not(target_os = "macos"))]
+            ModifierKeyCode::LeftControl => write!(f, "Left Ctrl"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::LeftAlt => write!(f, "Left Option"),
+            #[cfg(not(target_os = "macos"))]
+            ModifierKeyCode::LeftAlt => write!(f, "Left Alt"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::LeftSuper => write!(f, "Left Command"),
+            #[cfg(target_os = "windows")]
+            ModifierKeyCode::LeftSuper => write!(f, "Left Windows"),
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            ModifierKeyCode::LeftSuper => write!(f, "Left Super"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::RightControl => write!(f, "Right Control"),
+            #[cfg(not(target_os = "macos"))]
+            ModifierKeyCode::RightControl => write!(f, "Right Ctrl"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::RightAlt => write!(f, "Right Option"),
+            #[cfg(not(target_os = "macos"))]
+            ModifierKeyCode::RightAlt => write!(f, "Right Alt"),
+            #[cfg(target_os = "macos")]
+            ModifierKeyCode::RightSuper => write!(f, "Right Command"),
+            #[cfg(target_os = "windows")]
+            ModifierKeyCode::RightSuper => write!(f, "Right Windows"),
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            ModifierKeyCode::RightSuper => write!(f, "Right Super"),
+        }
+    }
+}
+
+#[cfg(feature = "crossterm")]
+mod crossterm_conv {
+    use super::*;
+    use crossterm::event as ct;
+
+    impl From<ct::MediaKeyCode> for MediaKeyCode {
+        fn from(c: ct::MediaKeyCode) -> Self {
+            match c {
+                ct::MediaKeyCode::Play => Self::Play,
+                ct::MediaKeyCode::Pause => Self::Pause,
+                ct::MediaKeyCode::PlayPause => Self::PlayPause,
+                ct::MediaKeyCode::Reverse => Self::Reverse,
+                ct::MediaKeyCode::Stop => Self::Stop,
+                ct::MediaKeyCode::FastForward => Self::FastForward,
+                ct::MediaKeyCode::Rewind => Self::Rewind,
+                ct::MediaKeyCode::TrackNext => Self::TrackNext,
+                ct::MediaKeyCode::TrackPrevious => Self::TrackPrevious,
+                ct::MediaKeyCode::Record => Self::Record,
+                ct::MediaKeyCode::LowerVolume => Self::LowerVolume,
+                ct::MediaKeyCode::RaiseVolume => Self::RaiseVolume,
+                ct::MediaKeyCode::MuteVolume => Self::MuteVolume,
+            }
+        }
+    }
+
+    impl From<ct::ModifierKeyCode> for ModifierKeyCode {
+        fn from(c: ct::ModifierKeyCode) -> Self {
+            match c {
+                ct::ModifierKeyCode::LeftShift => Self::LeftShift,
+                ct::ModifierKeyCode::LeftControl => Self::LeftControl,
+                ct::ModifierKeyCode::LeftAlt => Self::LeftAlt,
+                ct::ModifierKeyCode::LeftSuper => Self::LeftSuper,
+                ct::ModifierKeyCode::LeftHyper => Self::LeftHyper,
+                ct::ModifierKeyCode::LeftMeta => Self::LeftMeta,
+                ct::ModifierKeyCode::RightShift => Self::RightShift,
+                ct::ModifierKeyCode::RightControl => Self::RightControl,
+                ct::ModifierKeyCode::RightAlt => Self::RightAlt,
+                ct::ModifierKeyCode::RightSuper => Self::RightSuper,
+                ct::ModifierKeyCode::RightHyper => Self::RightHyper,
+                ct::ModifierKeyCode::RightMeta => Self::RightMeta,
+                ct::ModifierKeyCode::IsoLevel3Shift => Self::IsoLevel3Shift,
+                ct::ModifierKeyCode::IsoLevel5Shift => Self::IsoLevel5Shift,
+            }
+        }
+    }
+
+    impl From<ct::KeyCode> for KeyCode {
+        fn from(c: ct::KeyCode) -> Self {
+            match c {
+                ct::KeyCode::Backspace => Self::Backspace,
+                ct::KeyCode::Enter => Self::Enter,
+                ct::KeyCode::Left => Self::Left,
+                ct::KeyCode::Right => Self::Right,
+                ct::KeyCode::Up => Self::Up,
+                ct::KeyCode::Down => Self::Down,
+                ct::KeyCode::Home => Self::Home,
+                ct::KeyCode::End => Self::End,
+                ct::KeyCode::PageUp => Self::PageUp,
+                ct::KeyCode::PageDown => Self::PageDown,
+                ct::KeyCode::Tab => Self::Tab,
+                ct::KeyCode::BackTab => Self::BackTab,
+                ct::KeyCode::Delete => Self::Delete,
+                ct::KeyCode::Insert => Self::Insert,
+                ct::KeyCode::F(n) => Self::F(n),
+                ct::KeyCode::Char(c) => Self::Char(c),
+                ct::KeyCode::Null => Self::Null,
+                ct::KeyCode::Esc => Self::Esc,
+                ct::KeyCode::CapsLock => Self::CapsLock,
+                ct::KeyCode::ScrollLock => Self::ScrollLock,
+                ct::KeyCode::NumLock => Self::NumLock,
+                ct::KeyCode::PrintScreen => Self::PrintScreen,
+                ct::KeyCode::Pause => Self::Pause,
+                ct::KeyCode::Menu => Self::Menu,
+                ct::KeyCode::KeypadBegin => Self::KeypadBegin,
+                ct::KeyCode::Media(m) => Self::Media(m.into()),
+                ct::KeyCode::Modifier(m) => Self::Modifier(m.into()),
+            }
+        }
+    }
+
+    impl From<ct::KeyModifiers> for KeyModifiers {
+        fn from(m: ct::KeyModifiers) -> Self {
+            // Bit layout is identical, so bits round-trip directly.
+            Self::from_bits_truncate(m.bits())
+        }
+    }
+
+    impl From<ct::KeyEventKind> for KeyEventKind {
+        fn from(k: ct::KeyEventKind) -> Self {
+            match k {
+                ct::KeyEventKind::Press => Self::Press,
+                ct::KeyEventKind::Repeat => Self::Repeat,
+                ct::KeyEventKind::Release => Self::Release,
+            }
+        }
+    }
+
+    impl From<ct::MouseButton> for MouseButton {
+        fn from(b: ct::MouseButton) -> Self {
+            match b {
+                ct::MouseButton::Left => Self::Left,
+                ct::MouseButton::Right => Self::Right,
+                ct::MouseButton::Middle => Self::Middle,
+            }
+        }
+    }
+
+    impl From<ct::MouseEventKind> for MouseEventKind {
+        fn from(k: ct::MouseEventKind) -> Self {
+            match k {
+                ct::MouseEventKind::Down(b) => Self::Down(b.into()),
+                ct::MouseEventKind::Up(b) => Self::Up(b.into()),
+                ct::MouseEventKind::Drag(b) => Self::Drag(b.into()),
+                ct::MouseEventKind::Moved => Self::Moved,
+                ct::MouseEventKind::ScrollDown => Self::ScrollDown,
+                ct::MouseEventKind::ScrollUp => Self::ScrollUp,
+                ct::MouseEventKind::ScrollLeft => Self::ScrollLeft,
+                ct::MouseEventKind::ScrollRight => Self::ScrollRight,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn display_matches_crossterm() {
+            let codes = [
+                ct::KeyCode::Backspace,
+                ct::KeyCode::Enter,
+                ct::KeyCode::Delete,
+                ct::KeyCode::F(12),
+                ct::KeyCode::Char(' '),
+                ct::KeyCode::Char('q'),
+                ct::KeyCode::PageUp,
+                ct::KeyCode::Media(ct::MediaKeyCode::PlayPause),
+                ct::KeyCode::Modifier(ct::ModifierKeyCode::LeftSuper),
+            ];
+            for code in codes {
+                assert_eq!(
+                    KeyCode::from(code).to_string(),
+                    code.to_string(),
+                    "display mismatch for {code:?}"
+                );
+            }
+            let modifiers =
+                ct::KeyModifiers::SHIFT | ct::KeyModifiers::CONTROL | ct::KeyModifiers::ALT;
+            assert_eq!(
+                KeyModifiers::from(modifiers).to_string(),
+                modifiers.to_string()
+            );
+        }
+
+        #[test]
+        fn key_modifiers_bits_match_crossterm() {
+            assert_eq!(KeyModifiers::SHIFT.bits(), ct::KeyModifiers::SHIFT.bits());
+            assert_eq!(
+                KeyModifiers::CONTROL.bits(),
+                ct::KeyModifiers::CONTROL.bits()
+            );
+            assert_eq!(KeyModifiers::ALT.bits(), ct::KeyModifiers::ALT.bits());
+            assert_eq!(KeyModifiers::SUPER.bits(), ct::KeyModifiers::SUPER.bits());
+            assert_eq!(KeyModifiers::HYPER.bits(), ct::KeyModifiers::HYPER.bits());
+            assert_eq!(KeyModifiers::META.bits(), ct::KeyModifiers::META.bits());
+        }
+    }
+}

--- a/packages/iocraft/src/hooks/use_output.rs
+++ b/packages/iocraft/src/hooks/use_output.rs
@@ -1,9 +1,8 @@
-use crate::{ComponentUpdater, Hook, Hooks};
+use crate::{backend::Passthrough, element::Output, ComponentUpdater, Hook, Hooks};
 use core::{
     pin::Pin,
     task::{Context, Poll, Waker},
 };
-use crossterm::{cursor, QueueableCommand};
 use std::sync::{Arc, Mutex};
 
 mod private {
@@ -56,21 +55,33 @@ impl UseOutput for Hooks<'_, '_> {
     }
 }
 
-enum Message {
-    Stdout(String),
-    StdoutNoNewline(String),
-    Stderr(String),
-    StderrNoNewline(String),
-}
-
 #[derive(Default)]
 struct UseOutputState {
-    queue: Vec<Message>,
+    queue: Vec<Passthrough<'static>>,
     waker: Option<Waker>,
-    appended_newline: Option<u16>,
 }
 
 impl UseOutputState {
+    fn push(&mut self, stream: Output, mut content: String, mut newline: bool) {
+        if !newline && content.ends_with('\n') {
+            // Move the trailing newline into the flag so the backend chooses
+            // the line terminator (see `Passthrough`).
+            content.pop();
+            if content.ends_with('\r') {
+                content.pop();
+            }
+            newline = true;
+        }
+        self.queue.push(Passthrough {
+            stream,
+            content: content.into(),
+            newline,
+        });
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+
     fn exec(&mut self, updater: &mut ComponentUpdater) {
         if self.queue.is_empty() {
             return;
@@ -82,73 +93,12 @@ impl UseOutputState {
         }
 
         updater.clear_terminal_output();
+
+        // The backend owns placement, newline choice (`\r\n` vs `\n`), and any
+        // cursor re-anchoring.
         let terminal = updater.terminal_mut().unwrap();
-        let needs_carriage_returns = terminal.is_raw_mode_enabled();
-
-        if let Some(col) = self.appended_newline {
-            let _ = terminal
-                .render_output()
-                .queue(cursor::MoveUp(1))
-                .and_then(|w| w.queue(cursor::MoveRight(col)));
-        }
-        // Flush render output to ensure escape sequences are sent before any
-        // cross-stream writes (e.g., stdout messages when rendering to stderr).
-        let _ = terminal.render_output().flush();
-
-        let mut needs_extra_newline = self.appended_newline.is_some();
-
-        for msg in self.queue.drain(..) {
-            match msg {
-                Message::Stdout(msg) => {
-                    let formatted = if needs_carriage_returns {
-                        format!("{}\r\n", msg)
-                    } else {
-                        format!("{}\n", msg)
-                    };
-                    let _ = terminal.stdout().write_all(formatted.as_bytes());
-                    needs_extra_newline = false;
-                }
-                Message::StdoutNoNewline(msg) => {
-                    let _ = terminal.stdout().write_all(msg.as_bytes());
-                    if !msg.is_empty() {
-                        needs_extra_newline = !msg.ends_with('\n');
-                    }
-                }
-                Message::Stderr(msg) => {
-                    let formatted = if needs_carriage_returns {
-                        format!("{}\r\n", msg)
-                    } else {
-                        format!("{}\n", msg)
-                    };
-                    let _ = terminal.stderr().write_all(formatted.as_bytes());
-                    needs_extra_newline = false;
-                }
-                Message::StderrNoNewline(msg) => {
-                    let _ = terminal.stderr().write_all(msg.as_bytes());
-                    if !msg.is_empty() {
-                        needs_extra_newline = !msg.ends_with('\n');
-                    }
-                }
-            }
-        }
-
-        if needs_extra_newline {
-            // Flush stdout and stderr so the terminal processes all written bytes
-            // before we query the cursor position. Without this, the cursor position
-            // would reflect the state before the no-newline message was rendered,
-            // causing subsequent appended output to be placed at the wrong column.
-            let _ = terminal.stdout().flush();
-            let _ = terminal.stderr().flush();
-            if let Ok(pos) = cursor::position() {
-                self.appended_newline = Some(pos.0);
-                let newline = if needs_carriage_returns { "\r\n" } else { "\n" };
-                let _ = terminal.render_output().write_all(newline.as_bytes());
-            } else {
-                self.appended_newline = None;
-            }
-        } else {
-            self.appended_newline = None;
-        }
+        let _ = terminal.print_above(&self.queue);
+        self.queue.clear();
     }
 }
 
@@ -163,20 +113,14 @@ impl StdoutHandle {
     /// output.
     pub fn println<S: ToString>(&self, msg: S) {
         let mut state = self.state.lock().unwrap();
-        state.queue.push(Message::Stdout(msg.to_string()));
-        if let Some(waker) = state.waker.take() {
-            waker.wake();
-        }
+        state.push(Output::Stdout, msg.to_string(), true);
     }
 
     /// Queues a message to be written asynchronously to stdout without a newline, above the
     /// rendered component output.
     pub fn print<S: ToString>(&self, msg: S) {
         let mut state = self.state.lock().unwrap();
-        state.queue.push(Message::StdoutNoNewline(msg.to_string()));
-        if let Some(waker) = state.waker.take() {
-            waker.wake();
-        }
+        state.push(Output::Stdout, msg.to_string(), false);
     }
 }
 
@@ -191,20 +135,14 @@ impl StderrHandle {
     /// output.
     pub fn println<S: ToString>(&self, msg: S) {
         let mut state = self.state.lock().unwrap();
-        state.queue.push(Message::Stderr(msg.to_string()));
-        if let Some(waker) = state.waker.take() {
-            waker.wake();
-        }
+        state.push(Output::Stderr, msg.to_string(), true);
     }
 
     /// Queues a message to be written asynchronously to stderr without a newline, above the
     /// rendered component output.
     pub fn print<S: ToString>(&self, msg: S) {
         let mut state = self.state.lock().unwrap();
-        state.queue.push(Message::StderrNoNewline(msg.to_string()));
-        if let Some(waker) = state.waker.take() {
-            waker.wake();
-        }
+        state.push(Output::Stderr, msg.to_string(), false);
     }
 }
 
@@ -289,6 +227,23 @@ mod tests {
                 .poll_change(&mut core::task::Context::from_waker(&noop_waker())),
             Poll::Ready(())
         );
+    }
+
+    #[test]
+    fn test_print_trailing_newline_normalization() {
+        let mut state = UseOutputState::default();
+        state.push(Output::Stdout, "done\n".to_string(), false);
+        state.push(Output::Stdout, "crlf\r\n".to_string(), false);
+        state.push(Output::Stdout, "blank\n\n".to_string(), true);
+
+        // A trailing newline in no-newline content moves into the flag.
+        assert_eq!(state.queue[0].content, "done");
+        assert!(state.queue[0].newline);
+        assert_eq!(state.queue[1].content, "crlf");
+        assert!(state.queue[1].newline);
+        // println content is left untouched; its newlines are intentional.
+        assert_eq!(state.queue[2].content, "blank\n\n");
+        assert!(state.queue[2].newline);
     }
 
     #[component]

--- a/packages/iocraft/src/hooks/use_terminal_events.rs
+++ b/packages/iocraft/src/hooks/use_terminal_events.rs
@@ -195,7 +195,7 @@ impl Hook for UseTerminalEventsImpl {
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use crossterm::event::MouseButton;
+    use crate::MouseButton;
     use futures::stream::{self, StreamExt};
     use macro_rules_attribute::apply;
     use smol_macros::test;

--- a/packages/iocraft/src/hooks/use_terminal_size.rs
+++ b/packages/iocraft/src/hooks/use_terminal_size.rs
@@ -1,8 +1,8 @@
 use crate::{
+    backend::terminal_size,
     hooks::{UseState, UseTerminalEvents},
     Hooks, TerminalEvent,
 };
-use crossterm::terminal;
 
 mod private {
     pub trait Sealed {}
@@ -17,7 +17,7 @@ pub trait UseTerminalSize: private::Sealed {
 
 impl UseTerminalSize for Hooks<'_, '_> {
     fn use_terminal_size(&mut self) -> (u16, u16) {
-        let mut size = self.use_state(|| terminal::size().unwrap_or((0, 0)));
+        let mut size = self.use_state(|| terminal_size().unwrap_or((0, 0)));
         self.use_terminal_events(move |event| {
             if let TerminalEvent::Resize(width, height) = event {
                 size.set((width, height));

--- a/packages/iocraft/src/lib.rs
+++ b/packages/iocraft/src/lib.rs
@@ -103,10 +103,13 @@
 // Those types will remain in their modules for the public API.
 
 mod any_key;
+mod backend;
 mod canvas;
+mod color;
 mod component;
 mod context;
 mod element;
+mod event;
 mod handler;
 mod hook;
 mod multimap;

--- a/packages/iocraft/src/render.rs
+++ b/packages/iocraft/src/render.rs
@@ -63,15 +63,6 @@ impl<'a, 'b, 'c, 'w> ComponentUpdater<'a, 'b, 'c, 'w> {
         self.context.terminal.as_mut().and_then(|t| t.events().ok())
     }
 
-    /// Returns whether the terminal is in raw mode.
-    pub fn is_terminal_raw_mode_enabled(&self) -> bool {
-        self.context
-            .terminal
-            .as_ref()
-            .map(|t| t.is_raw_mode_enabled())
-            .unwrap_or(false)
-    }
-
     /// Removes the currently rendered output from the terminal, e.g. to allow for the printing of
     /// output above the component.
     pub fn clear_terminal_output(&mut self) {

--- a/packages/iocraft/src/style.rs
+++ b/packages/iocraft/src/style.rs
@@ -7,7 +7,7 @@ use taffy::{
 };
 
 // Re-export basic enum types.
-pub use crossterm::style::Color;
+pub use crate::color::Color;
 pub use taffy::style::{
     AlignContent, AlignItems, Display, FlexDirection, FlexWrap, JustifyContent, Overflow, Position,
 };

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -1,9 +1,6 @@
-use crate::{canvas::Canvas, element::Output};
-use crossterm::{
-    cursor,
-    event::{self, Event, EventStream},
-    terminal, ExecutableCommand, QueueableCommand,
-};
+use crate::backend::{Passthrough, TerminalBackend};
+use crate::canvas::Canvas;
+use crate::element::Output;
 use futures::{
     channel::mpsc,
     future::pending,
@@ -11,15 +8,26 @@ use futures::{
 };
 use std::{
     collections::VecDeque,
-    io::{self, stdin, IsTerminal, Write},
+    io::{self, Write},
     mem,
     pin::Pin,
     sync::{Arc, Mutex, Weak},
     task::{Context, Poll, Waker},
 };
 
-// Re-exports for basic types.
-pub use crossterm::event::{KeyCode, KeyEventKind, KeyEventState, KeyModifiers, MouseEventKind};
+#[cfg(feature = "crossterm")]
+use crossterm::{
+    cursor,
+    event::{self, Event, EventStream},
+    terminal, ExecutableCommand, QueueableCommand,
+};
+#[cfg(feature = "crossterm")]
+use std::io::{stdin, IsTerminal};
+
+// Re-exports for basic input event types (owned by iocraft; see `crate::event`).
+pub use crate::event::{
+    KeyCode, KeyEventKind, KeyModifiers, MediaKeyCode, ModifierKeyCode, MouseButton, MouseEventKind,
+};
 
 /// An event fired when a key is pressed.
 #[non_exhaustive]
@@ -111,23 +119,7 @@ impl Stream for TerminalEvents {
     }
 }
 
-trait TerminalImpl: Write + Send {
-    fn refresh_size(&mut self) {}
-    fn size(&self) -> Option<(u16, u16)> {
-        None
-    }
-    fn set_mouse_capture(&mut self, _enabled: bool) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn is_raw_mode_enabled(&self) -> bool;
-    fn clear_canvas(&mut self) -> io::Result<()>;
-    fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()>;
-    fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>>;
-    fn dest(&mut self) -> &mut dyn Write;
-    fn alt(&mut self) -> &mut dyn Write;
-}
-
+#[cfg(feature = "crossterm")]
 fn clear_canvas_inline(
     dest: &mut (impl Write + ?Sized),
     prev_canvas_height: u16,
@@ -144,10 +136,17 @@ fn clear_canvas_inline(
     }
 }
 
-struct StdTerminal<'a> {
+/// A [`TerminalBackend`] that renders ANSI escape sequences to stdout/stderr
+/// via crossterm. This is iocraft's default backend.
+#[cfg(feature = "crossterm")]
+pub(crate) struct CrosstermBackend<'a> {
     input_is_terminal: bool,
+    /// The render destination (whichever of stdout/stderr `output` selects).
     dest: Box<dyn Write + Send + 'a>,
+    /// The other standard stream.
     alt: Box<dyn Write + Send + 'a>,
+    /// Which standard stream `dest` corresponds to.
+    output: Output,
     fullscreen: bool,
     mouse_capture: bool,
     raw_mode_enabled: bool,
@@ -156,19 +155,124 @@ struct StdTerminal<'a> {
     prev_canvas_height: u16,
     prev_size_on_write: Option<(u16, u16)>,
     size: Option<(u16, u16)>,
+    /// Column recorded after a no-newline passthrough write, so the next
+    /// `print_above` can re-anchor the cursor. See [`Self::print_above`].
+    ///
+    /// This is deliberately backend-wide rather than per `use_output` hook:
+    /// there is only one physical cursor, so output from different hooks
+    /// interleaves the same way plain `print!`/`println!` calls would.
+    passthrough_appended_newline: Option<u16>,
 }
 
-impl Write for StdTerminal<'_> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.dest.write(buf)
+#[cfg(feature = "crossterm")]
+impl CrosstermBackend<'_> {
+    /// Returns the writer for the given standard stream. `dest` is the render
+    /// target; the other stream is `alt`.
+    fn stream_writer(&mut self, stream: Output) -> &mut (dyn Write + Send) {
+        if stream == self.output {
+            &mut *self.dest
+        } else {
+            &mut *self.alt
+        }
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.dest.flush()
+    /// The fallible body of [`TerminalBackend::print_above`]. Per-message
+    /// writes are best effort: a failed message doesn't prevent later messages
+    /// (possibly bound for the other stream) from being written. Returns the
+    /// first error encountered.
+    fn print_above_impl(&mut self, messages: &[Passthrough<'_>]) -> io::Result<()> {
+        let needs_carriage_returns = self.raw_mode_enabled;
+        let newline: &[u8] = if needs_carriage_returns {
+            b"\r\n"
+        } else {
+            b"\n"
+        };
+
+        // If we appended a newline after the last no-newline message, move back
+        // up to that column so this batch continues where it left off.
+        if let Some(col) = self.passthrough_appended_newline {
+            self.dest
+                .queue(cursor::MoveUp(1))
+                .and_then(|w| w.queue(cursor::MoveRight(col)))?;
+        }
+        // Flush the render stream so its escape sequences are emitted before any
+        // cross-stream writes (e.g. stdout messages when rendering to stderr).
+        self.dest.flush()?;
+
+        let mut needs_extra_newline = self.passthrough_appended_newline.is_some();
+        let mut first_err = None;
+
+        for msg in messages {
+            let w = self.stream_writer(msg.stream);
+            let mut result =
+                write_passthrough_content(&mut *w, &msg.content, needs_carriage_returns);
+            if result.is_ok() && msg.newline {
+                result = w.write_all(newline);
+            }
+            match result {
+                Ok(()) => {
+                    if msg.newline {
+                        needs_extra_newline = false;
+                    } else if !msg.content.is_empty() {
+                        // `Passthrough` content without the newline flag never
+                        // ends with a newline (use_output normalizes it), so a
+                        // trailing newline must be appended and re-anchored.
+                        needs_extra_newline = true;
+                    }
+                }
+                Err(err) => {
+                    if first_err.is_none() {
+                        first_err = Some(err);
+                    }
+                }
+            }
+        }
+        if let Some(err) = first_err {
+            return Err(err);
+        }
+
+        if needs_extra_newline {
+            // Flush both streams so the terminal has processed everything before
+            // we query the cursor position, otherwise the recorded column would
+            // reflect stale state.
+            self.dest.flush()?;
+            self.alt.flush()?;
+            if let Ok(pos) = cursor::position() {
+                self.passthrough_appended_newline = Some(pos.0);
+                self.dest.write_all(newline)?;
+            } else {
+                self.passthrough_appended_newline = None;
+            }
+        } else {
+            self.passthrough_appended_newline = None;
+        }
+        Ok(())
     }
 }
 
-impl TerminalImpl for StdTerminal<'_> {
+/// Writes passthrough content, translating embedded `\n` to `\r\n` when the
+/// terminal is in raw mode, where a bare `\n` doesn't return the cursor to
+/// column 0 and multi-line content would stair-step.
+#[cfg(feature = "crossterm")]
+fn write_passthrough_content(
+    w: &mut (dyn Write + Send),
+    content: &str,
+    needs_carriage_returns: bool,
+) -> io::Result<()> {
+    if !needs_carriage_returns || !content.contains('\n') {
+        return w.write_all(content.as_bytes());
+    }
+    for (i, segment) in content.split('\n').enumerate() {
+        if i > 0 {
+            w.write_all(b"\r\n")?;
+        }
+        w.write_all(segment.as_bytes())?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "crossterm")]
+impl TerminalBackend for CrosstermBackend<'_> {
     fn refresh_size(&mut self) {
         self.size = terminal::size().ok()
     }
@@ -189,10 +293,6 @@ impl TerminalImpl for StdTerminal<'_> {
             }
         }
         Ok(())
-    }
-
-    fn is_raw_mode_enabled(&self) -> bool {
-        self.raw_mode_enabled
     }
 
     fn clear_canvas(&mut self) -> io::Result<()> {
@@ -353,6 +453,30 @@ impl TerminalImpl for StdTerminal<'_> {
         Ok(())
     }
 
+    fn begin_frame(&mut self) -> io::Result<()> {
+        self.dest.execute(terminal::BeginSynchronizedUpdate)?;
+        Ok(())
+    }
+
+    fn end_frame(&mut self) -> io::Result<()> {
+        self.dest.execute(terminal::EndSynchronizedUpdate)?;
+        Ok(())
+    }
+
+    fn print_above(&mut self, messages: &[Passthrough<'_>]) -> io::Result<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+        let result = self.print_above_impl(messages);
+        if result.is_err() {
+            // After a failed or partial write the cursor position is unknown,
+            // so never re-anchor onto it. The worst case is a stray blank line
+            // rather than overwriting previously rendered output.
+            self.passthrough_appended_newline = None;
+        }
+        result
+    }
+
     fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>> {
         if !self.input_is_terminal {
             return Ok(stream::pending().boxed());
@@ -364,16 +488,16 @@ impl TerminalImpl for StdTerminal<'_> {
             .filter_map(|event| async move {
                 match event {
                     Ok(Event::Key(event)) => Some(TerminalEvent::Key(KeyEvent {
-                        code: event.code,
-                        modifiers: event.modifiers,
-                        kind: event.kind,
+                        code: event.code.into(),
+                        modifiers: event.modifiers.into(),
+                        kind: event.kind.into(),
                     })),
                     Ok(Event::Mouse(event)) => {
                         Some(TerminalEvent::FullscreenMouse(FullscreenMouseEvent {
-                            modifiers: event.modifiers,
+                            modifiers: event.modifiers.into(),
                             column: event.column,
                             row: event.row,
-                            kind: event.kind,
+                            kind: event.kind.into(),
                         }))
                     }
                     Ok(Event::Resize(width, height)) => Some(TerminalEvent::Resize(width, height)),
@@ -382,26 +506,26 @@ impl TerminalImpl for StdTerminal<'_> {
             })
             .boxed())
     }
-
-    fn dest(&mut self) -> &mut dyn Write {
-        &mut *self.dest
-    }
-
-    fn alt(&mut self) -> &mut dyn Write {
-        &mut *self.alt
-    }
 }
 
-impl<'a> StdTerminal<'a> {
+#[cfg(feature = "crossterm")]
+impl<'a> CrosstermBackend<'a> {
     fn new(
-        dest: Box<dyn Write + Send + 'a>,
-        alt: Box<dyn Write + Send + 'a>,
+        stdout: Box<dyn Write + Send + 'a>,
+        stderr: Box<dyn Write + Send + 'a>,
+        output: Output,
         fullscreen: bool,
         mouse_capture: bool,
     ) -> io::Result<Self> {
+        // dest is the render destination, alt is the other stream
+        let (dest, alt) = match output {
+            Output::Stdout => (stdout, stderr),
+            Output::Stderr => (stderr, stdout),
+        };
         let mut term = Self {
             dest,
             alt,
+            output,
             input_is_terminal: stdin().is_terminal(),
             fullscreen,
             mouse_capture,
@@ -411,6 +535,7 @@ impl<'a> StdTerminal<'a> {
             prev_canvas_height: 0,
             size: None,
             prev_size_on_write: None,
+            passthrough_appended_newline: None,
         };
         term.dest.queue(cursor::Hide)?;
         if fullscreen {
@@ -447,7 +572,8 @@ impl<'a> StdTerminal<'a> {
     }
 }
 
-impl Drop for StdTerminal<'_> {
+#[cfg(feature = "crossterm")]
+impl Drop for CrosstermBackend<'_> {
     fn drop(&mut self) {
         let _ = self.set_raw_mode_enabled(false);
         if self.fullscreen {
@@ -500,8 +626,6 @@ impl Default for MockTerminalConfig {
 struct MockTerminal {
     config: MockTerminalConfig,
     output: mpsc::UnboundedSender<Canvas>,
-    dummy_dest: io::Sink,
-    dummy_alt: io::Sink,
 }
 
 impl MockTerminal {
@@ -512,29 +636,13 @@ impl MockTerminal {
             Self {
                 config,
                 output: output_tx,
-                dummy_dest: io::sink(),
-                dummy_alt: io::sink(),
             },
             output,
         )
     }
 }
 
-impl Write for MockTerminal {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl TerminalImpl for MockTerminal {
-    fn is_raw_mode_enabled(&self) -> bool {
-        false
-    }
-
+impl TerminalBackend for MockTerminal {
     fn clear_canvas(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -544,24 +652,20 @@ impl TerminalImpl for MockTerminal {
         Ok(())
     }
 
+    fn print_above(&mut self, _messages: &[Passthrough<'_>]) -> io::Result<()> {
+        // The mock terminal discards passthrough output.
+        Ok(())
+    }
+
     fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>> {
         let mut events = stream::pending().boxed();
         mem::swap(&mut events, &mut self.config.events);
         Ok(events.chain(stream::pending()).boxed())
     }
-
-    fn dest(&mut self) -> &mut dyn Write {
-        &mut self.dummy_dest
-    }
-
-    fn alt(&mut self) -> &mut dyn Write {
-        &mut self.dummy_alt
-    }
 }
 
 pub(crate) struct Terminal<'a> {
-    inner: Box<dyn TerminalImpl + 'a>,
-    output: Output,
+    inner: Box<dyn TerminalBackend + 'a>,
     event_stream: Option<BoxStream<'static, TerminalEvent>>,
     subscribers: Vec<Weak<Mutex<TerminalEventsInner>>>,
     received_ctrl_c: bool,
@@ -569,6 +673,20 @@ pub(crate) struct Terminal<'a> {
 }
 
 impl<'a> Terminal<'a> {
+    /// Builds a terminal from an arbitrary [`TerminalBackend`].
+    pub fn with_backend(backend: Box<dyn TerminalBackend + 'a>) -> Self {
+        Self {
+            inner: backend,
+            event_stream: None,
+            subscribers: Vec::new(),
+            received_ctrl_c: false,
+            ignore_ctrl_c: false,
+        }
+    }
+
+    /// Builds a terminal backed by crossterm, rendering to `output` (with the
+    /// other stream available for passthrough writes).
+    #[cfg(feature = "crossterm")]
     pub fn new(
         stdout: Box<dyn Write + Send + 'a>,
         stderr: Box<dyn Write + Send + 'a>,
@@ -576,19 +694,28 @@ impl<'a> Terminal<'a> {
         fullscreen: bool,
         mouse_capture: bool,
     ) -> io::Result<Self> {
-        // dest is the render destination, alt is the other stream
-        let (dest, alt) = match output {
-            Output::Stdout => (stdout, stderr),
-            Output::Stderr => (stderr, stdout),
-        };
-        Ok(Self {
-            inner: Box::new(StdTerminal::new(dest, alt, fullscreen, mouse_capture)?),
+        Ok(Self::with_backend(Box::new(CrosstermBackend::new(
+            stdout,
+            stderr,
             output,
-            event_stream: None,
-            subscribers: Vec::new(),
-            received_ctrl_c: false,
-            ignore_ctrl_c: false,
-        })
+            fullscreen,
+            mouse_capture,
+        )?)))
+    }
+
+    /// Without a terminal backend compiled in, construction always fails.
+    #[cfg(not(feature = "crossterm"))]
+    pub fn new(
+        _stdout: Box<dyn Write + Send + 'a>,
+        _stderr: Box<dyn Write + Send + 'a>,
+        _output: Output,
+        _fullscreen: bool,
+        _mouse_capture: bool,
+    ) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no terminal backend is enabled; enable the `crossterm` feature",
+        ))
     }
 
     pub fn enable_mouse_capture(&mut self) -> io::Result<()> {
@@ -601,10 +728,6 @@ impl<'a> Terminal<'a> {
 
     pub fn ignore_ctrl_c(&mut self) {
         self.ignore_ctrl_c = true;
-    }
-
-    pub fn is_raw_mode_enabled(&self) -> bool {
-        self.inner.is_raw_mode_enabled()
     }
 
     pub fn refresh_size(&mut self) {
@@ -627,25 +750,9 @@ impl<'a> Terminal<'a> {
         self.received_ctrl_c
     }
 
-    /// Returns a mutable reference to the stdout handle.
-    pub fn stdout(&mut self) -> &mut dyn Write {
-        match self.output {
-            Output::Stdout => self.inner.dest(),
-            Output::Stderr => self.inner.alt(),
-        }
-    }
-
-    /// Returns a mutable reference to the stderr handle.
-    pub fn stderr(&mut self) -> &mut dyn Write {
-        match self.output {
-            Output::Stdout => self.inner.alt(),
-            Output::Stderr => self.inner.dest(),
-        }
-    }
-
-    /// Returns a mutable reference to the render output handle (stdout or stderr based on output setting).
-    pub fn render_output(&mut self) -> &mut dyn Write {
-        self.inner.dest()
+    /// Emits passthrough output above the rendered canvas (used by `use_output`).
+    pub fn print_above(&mut self, messages: &[Passthrough<'_>]) -> io::Result<()> {
+        self.inner.print_above(messages)
     }
 
     /// Wraps a series of terminal updates in a synchronized update block, making sure to end the
@@ -709,50 +816,30 @@ impl<'a> Terminal<'a> {
 impl Terminal<'static> {
     pub fn mock(config: MockTerminalConfig) -> (Self, MockTerminalOutputStream) {
         let (term, output_stream) = MockTerminal::new(config);
-        (
-            Self {
-                inner: Box::new(term),
-                output: Output::Stdout,
-                event_stream: None,
-                subscribers: Vec::new(),
-                received_ctrl_c: false,
-                ignore_ctrl_c: false,
-            },
-            output_stream,
-        )
-    }
-}
-
-impl Write for Terminal<'_> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
+        (Self::with_backend(Box::new(term)), output_stream)
     }
 }
 
 /// Synchronized update terminal guard.
-/// Enters synchronized update on creation, exits when dropped.
+/// Begins a frame on creation, ends it when dropped (even on error or panic).
 pub(crate) struct SynchronizedUpdate<'a, 'b> {
     inner: &'a mut Terminal<'b>,
 }
 
 impl<'a, 'b> SynchronizedUpdate<'a, 'b> {
     pub fn begin(terminal: &'a mut Terminal<'b>) -> io::Result<Self> {
-        terminal.execute(terminal::BeginSynchronizedUpdate)?;
+        terminal.inner.begin_frame()?;
         Ok(Self { inner: terminal })
     }
 }
 
 impl Drop for SynchronizedUpdate<'_, '_> {
     fn drop(&mut self) {
-        let _ = self.inner.execute(terminal::EndSynchronizedUpdate);
+        let _ = self.inner.inner.end_frame();
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "crossterm"))]
 mod tests {
     use super::*;
     use crate::prelude::*;
@@ -793,11 +880,70 @@ mod tests {
             true,
         )
         .unwrap();
-        assert!(!terminal.is_raw_mode_enabled());
         assert!(!terminal.received_ctrl_c());
-        assert!(!terminal.is_raw_mode_enabled());
         let canvas = Canvas::new(10, 1);
         terminal.write_canvas(None, &canvas).unwrap();
+    }
+
+    #[test]
+    fn test_print_above_write_error_best_effort() {
+        struct FailingWriter;
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "broken pipe"))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let (dest, dest_buf) = new_test_writer();
+        let mut term = new_inline_term(dest, 0);
+        term.alt = Box::new(FailingWriter);
+        term.passthrough_appended_newline = Some(3);
+
+        let messages = [
+            Passthrough {
+                stream: Output::Stderr, // the alt stream, which fails
+                content: "lost".into(),
+                newline: true,
+            },
+            Passthrough {
+                stream: Output::Stdout, // the render stream, which works
+                content: "kept".into(),
+                newline: true,
+            },
+        ];
+        let result = term.print_above(&messages);
+        assert!(result.is_err());
+
+        // Later messages must still be written after an earlier write fails.
+        let written = String::from_utf8(dest_buf.lock().unwrap().clone()).unwrap();
+        assert!(written.contains("kept"), "got: {written:?}");
+
+        // After an error the cursor position is unknown, so the re-anchor
+        // state must reset rather than go stale.
+        assert_eq!(term.passthrough_appended_newline, None);
+    }
+
+    #[test]
+    fn test_print_above_translates_newlines_in_raw_mode() {
+        let (dest, dest_buf) = new_test_writer();
+        let mut term = new_inline_term(dest, 0);
+        term.raw_mode_enabled = true;
+
+        let messages = [Passthrough {
+            stream: Output::Stdout,
+            content: "line1\nline2".into(),
+            newline: true,
+        }];
+        term.print_above(&messages).unwrap();
+
+        // Embedded newlines must become \r\n in raw mode, or multi-line
+        // content stair-steps.
+        let written = String::from_utf8(dest_buf.lock().unwrap().clone()).unwrap();
+        assert_eq!(written, "line1\r\nline2\r\n");
+        assert_eq!(term.passthrough_appended_newline, None);
     }
 
     fn render_canvas_to_vt(canvas: &Canvas, cols: usize, rows: usize) -> avt::Vt {
@@ -985,11 +1131,12 @@ mod tests {
         dest: TestWriter,
         prev_canvas_top_row: u16,
         prev_canvas_height: u16,
-    ) -> StdTerminal<'static> {
-        StdTerminal {
+    ) -> CrosstermBackend<'static> {
+        CrosstermBackend {
             input_is_terminal: false,
             dest: Box::new(dest),
             alt: Box::new(io::sink()),
+            output: Output::Stdout,
             fullscreen: true,
             mouse_capture: false,
             raw_mode_enabled: false,
@@ -998,10 +1145,11 @@ mod tests {
             prev_canvas_height,
             size: None,
             prev_size_on_write: None,
+            passthrough_appended_newline: None,
         }
     }
 
-    fn new_inline_term(dest: TestWriter, prev_canvas_height: u16) -> StdTerminal<'static> {
+    fn new_inline_term(dest: TestWriter, prev_canvas_height: u16) -> CrosstermBackend<'static> {
         new_inline_term_with_size(dest, prev_canvas_height, (10, 10))
     }
 
@@ -1009,11 +1157,12 @@ mod tests {
         dest: TestWriter,
         prev_canvas_height: u16,
         term_size: (u16, u16),
-    ) -> StdTerminal<'static> {
-        StdTerminal {
+    ) -> CrosstermBackend<'static> {
+        CrosstermBackend {
             input_is_terminal: false,
             dest: Box::new(dest),
             alt: Box::new(io::sink()),
+            output: Output::Stdout,
             fullscreen: false,
             mouse_capture: false,
             raw_mode_enabled: false,
@@ -1022,6 +1171,7 @@ mod tests {
             prev_canvas_height,
             size: Some(term_size),
             prev_size_on_write: None,
+            passthrough_appended_newline: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Introduces a crate-internal `TerminalBackend` trait as the seam between iocraft's renderer and a concrete terminal, so the crate is no longer hard-wired to crossterm. The built-in `CrosstermBackend` is gated behind a new default-on `crossterm` feature; with `--no-default-features` the crate builds without crossterm.

- New iocraft-owned `Color` (`src/color.rs`) and input-event types — `KeyCode`, `KeyModifiers`, `MouseEventKind`, `MouseButton`, etc. (`src/event.rs`) — with `From` conversions to/from the crossterm types when the feature is enabled, and byte-for-byte parity tests against crossterm's ANSI/`Display` output.
- `use_output` passthrough (`print`/`println` above the UI) now flows through `TerminalBackend::print_above`, which owns newline choice, raw-mode `\r\n` translation, and cursor re-anchoring.
- `ElementExt::write_to_raw_fd` now takes `AsFd` instead of `AsRawFd`.

This is a breaking change (`0.8.x` → `0.9.0`); see the changelog entry for the downstream migration notes.

## Follow-up fixes (from review)

- **Restore `NO_COLOR` support** — `SgrColor::Display` now emits nothing when `NO_COLOR` is set (memoized), matching what crossterm's `Colored` did before the decoupling. Applies to both `write_ansi` output and the interactive render loop.
- **Restore terminal-size error propagation** — `write_to_is_terminal` / `write_to_raw_fd` again surface a genuine failure to size a real terminal, falling back to plain output only when no backend is compiled in (`ErrorKind::Unsupported`).
- Documented the breaking public-API changes in the changelog.

## Testing

- `cargo test -p iocraft` — 105 unit + 28 doc tests pass (incl. new `no_color_suppresses_sgr_output` and `test_write_sized_or_plain_size_error_handling`).
- `cargo build -p iocraft --no-default-features` builds clean.
- `cargo clippy -p iocraft` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)