### PR TITLE
fix: probe keyboard enhancement support before the first synchronized update

### DIFF
--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -151,6 +151,7 @@ struct StdTerminal<'a> {
     fullscreen: bool,
     mouse_capture: bool,
     raw_mode_enabled: bool,
+    supports_keyboard_enhancement: bool,
     enabled_keyboard_enhancement: bool,
     prev_canvas_top_row: u16,
     prev_canvas_height: u16,
@@ -399,13 +400,20 @@ impl<'a> StdTerminal<'a> {
         fullscreen: bool,
         mouse_capture: bool,
     ) -> io::Result<Self> {
+        let input_is_terminal = stdin().is_terminal();
+        // The probe blocks on a query response, and some terminals (e.g. WezTerm)
+        // don't answer queries while a synchronized update is open — probing lazily
+        // from within a render would stall until the query times out.
+        let supports_keyboard_enhancement =
+            input_is_terminal && terminal::supports_keyboard_enhancement().unwrap_or(false);
         let mut term = Self {
             dest,
             alt,
-            input_is_terminal: stdin().is_terminal(),
+            input_is_terminal,
             fullscreen,
             mouse_capture,
             raw_mode_enabled: false,
+            supports_keyboard_enhancement,
             enabled_keyboard_enhancement: false,
             prev_canvas_top_row: 0,
             prev_canvas_height: 0,
@@ -422,7 +430,7 @@ impl<'a> StdTerminal<'a> {
     fn set_raw_mode_enabled(&mut self, raw_mode_enabled: bool) -> io::Result<()> {
         if raw_mode_enabled != self.raw_mode_enabled {
             if raw_mode_enabled {
-                if terminal::supports_keyboard_enhancement().unwrap_or(false) {
+                if self.supports_keyboard_enhancement {
                     self.dest.execute(event::PushKeyboardEnhancementFlags(
                         event::KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
                     ))?;
@@ -993,6 +1001,7 @@ mod tests {
             fullscreen: true,
             mouse_capture: false,
             raw_mode_enabled: false,
+            supports_keyboard_enhancement: false,
             enabled_keyboard_enhancement: false,
             prev_canvas_top_row,
             prev_canvas_height,
@@ -1017,6 +1026,7 @@ mod tests {
             fullscreen: false,
             mouse_capture: false,
             raw_mode_enabled: false,
+            supports_keyboard_enhancement: false,
             enabled_keyboard_enhancement: false,
             prev_canvas_top_row: 0,
             prev_canvas_height,


### PR DESCRIPTION
## What It Does

Moves the `supports_keyboard_enhancement()` probe from `set_raw_mode_enabled` (lazily hit during the first render) into `StdTerminal::new`, caching the result in a field.

The probe is a blocking query round-trip with a 2s timeout, and the first render runs inside a synchronized update (`CSI ?2026h`). WezTerm doesn't answer queries while a synchronized update is open, so the probe always timed out there. That meant a 2 second startup stall, and keyboard enhancement detection wrongly concluding the protocol is unsupported even though WezTerm answers the same probe in about 4ms outside an update. Probing at terminal construction, before any bytes are written, avoids the interaction entirely. It also helps on Alacritty, which buffers mid-update queries for up to 150ms.

Verified against WezTerm 20260707-093716-fff02ca5: without this change startup stalls for the full 2 seconds; with it the first frame renders immediately and `REPORT_EVENT_TYPES` is pushed as expected.

## Related Issues

Fixes #125. Related: #74, wezterm/wezterm#7918 (the WezTerm-side report), wezterm/wezterm#4928.