### PR TITLE
fix(text_input): preserve cursor after Unicode insertion

### DIFF
--- a/packages/iocraft/src/components/text_input.rs
+++ b/packages/iocraft/src/components/text_input.rs
@@ -597,20 +597,11 @@ fn new_cursor_offset(
     hint: NewCursorOffsetHint,
 ) -> usize {
     let has_same_head = value.len() >= cursor_offset
-        && value
-            .chars()
-            .zip(prev_value.chars())
-            .take(cursor_offset)
-            .all(|(a, b)| a == b);
+        && value.as_bytes()[..cursor_offset] == prev_value.as_bytes()[..cursor_offset];
 
     let tail_len = prev_value.len() - cursor_offset;
     let has_same_tail = value.len() >= tail_len
-        && value
-            .chars()
-            .rev()
-            .zip(prev_value.chars().rev())
-            .take(tail_len)
-            .all(|(a, b)| a == b);
+        && value.as_bytes()[value.len() - tail_len..] == prev_value.as_bytes()[cursor_offset..];
 
     if value.len() >= prev_value.len() && has_same_head && has_same_tail {
         // insertion (or no change)
@@ -855,6 +846,18 @@ mod tests {
 
     #[test]
     fn test_new_cursor_offset() {
+        let mixed_text = "你好世界，Hello World";
+        let cursor_offset = mixed_text.find('W').unwrap();
+        assert_eq!(
+            new_cursor_offset(
+                mixed_text,
+                cursor_offset,
+                "你好世界，Hello aWorld",
+                NewCursorOffsetHint::None
+            ),
+            cursor_offset + 1
+        );
+
         assert_eq!(
             new_cursor_offset("", 0, "foo", NewCursorOffsetHint::None),
             3


### PR DESCRIPTION
## What It Does

TextInput tracks cursor offsets in bytes, but new_cursor_offset compared characters while using byte counts as iterator limits. With a multibyte prefix, this extended the head comparison past the cursor and moved the cursor to the end after an insertion.

This change compares the unchanged head and tail as byte slices and adds a regression for inserting ASCII text into a mixed Chinese/English value.

## Related Issues

Fixes #208

## Testing

- cargo test -p iocraft components::text_input::tests (8 passed)
- cargo build --workspace
- cargo fmt --check
- cargo doc --workspace --no-deps with warnings denied
- cargo clippy --workspace with the one unchanged Rust 1.95 baseline lint allowed
- full workspace tests: 92 passed, with the same two terminal styled-text failures reproduced on untouched main under local Rust 1.95/macOS