### PR TITLE
feat: add a real terminal cursor API

### DIFF
--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -100,6 +100,35 @@ impl CanvasCell {
     }
 }
 
+/// The shape of the terminal cursor.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorShape {
+    /// The terminal's default cursor shape.
+    #[default]
+    Default,
+    /// A block cursor.
+    Block,
+    /// A vertical bar cursor.
+    Bar,
+    /// An underline cursor.
+    Underline,
+}
+
+/// A request to place the real terminal cursor at a canvas cell.
+///
+/// A low-level component can request this during drawing via
+/// [`ComponentDrawer::set_cursor`](crate::ComponentDrawer::set_cursor). If no
+/// component requests a cursor, the terminal cursor stays hidden.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cursor {
+    /// Column, in canvas coordinates.
+    pub x: u16,
+    /// Row, in canvas coordinates.
+    pub y: u16,
+    /// The desired cursor shape.
+    pub shape: CursorShape,
+}
+
 /// `Canvas` is the medium that output is drawn to before being rendered to the terminal or other
 /// destinations.
 ///
@@ -111,6 +140,7 @@ impl CanvasCell {
 pub struct Canvas {
     width: usize,
     cells: Vec<Vec<CanvasCell>>,
+    cursor: Option<Cursor>,
 }
 
 impl Canvas {
@@ -119,6 +149,7 @@ impl Canvas {
         Self {
             width,
             cells: vec![vec![CanvasCell::default(); width]; height],
+            cursor: None,
         }
     }
 
@@ -136,6 +167,17 @@ impl Canvas {
     /// out of bounds.
     pub fn cell(&self, x: usize, y: usize) -> Option<&CanvasCell> {
         self.cells.get(y).and_then(|row| row.get(x))
+    }
+
+    /// Returns the requested terminal cursor, if any component set one.
+    pub fn cursor(&self) -> Option<Cursor> {
+        self.cursor
+    }
+
+    /// Requests the terminal cursor be placed at the given canvas cell. The last
+    /// request wins, so the most recently drawn (topmost) component takes it.
+    pub fn set_cursor(&mut self, cursor: Cursor) {
+        self.cursor = Some(cursor);
     }
 
     /// Extracts plain text from a rectangular region of the canvas.

--- a/packages/iocraft/src/render.rs
+++ b/packages/iocraft/src/render.rs
@@ -1,5 +1,5 @@
 use crate::{
-    canvas::{Canvas, CanvasSubviewMut},
+    canvas::{Canvas, CanvasSubviewMut, Cursor, CursorShape},
     component::{ComponentHelperExt, Components, InstantiatedComponent},
     context::{Context, ContextStack, SystemContext},
     element::ElementExt,
@@ -270,6 +270,20 @@ impl ComponentDrawer<'_> {
         )
     }
 
+    /// Requests that the real terminal cursor be placed at `(x, y)`, relative to
+    /// this component's top-left, with the given shape. The most recently drawn
+    /// (topmost) requester wins; if no component requests a cursor, the terminal
+    /// cursor stays hidden.
+    pub fn set_cursor(&mut self, x: u16, y: u16, shape: CursorShape) {
+        let abs_x = (self.node_position.x + x as i16).max(0) as u16;
+        let abs_y = (self.node_position.y + y as i16).max(0) as u16;
+        self.context.canvas.set_cursor(Cursor {
+            x: abs_x,
+            y: abs_y,
+            shape,
+        });
+    }
+
     /// Prepares to begin drawing a node by moving to the node's position and invoking the given
     /// closure.
     pub(crate) fn for_child_node_layout<F>(&mut self, node_id: NodeId, f: F)
@@ -476,6 +490,7 @@ impl<'a> Tree<'a> {
                         prev_canvas.as_ref()
                     };
                     term.write_canvas(prev, &output.canvas)?;
+                    term.write_cursor(output.canvas.cursor().as_ref())?;
                 }
                 prev_canvas = Some(output.canvas);
                 Ok(())
@@ -598,6 +613,61 @@ mod tests {
                 #((0..2).map(|i| element! { MyInnerComponent(key: i, label: format!("c{}", i)) }))
             }
         }
+    }
+
+    #[test]
+    fn test_component_cursor() {
+        #[derive(Default, Props)]
+        struct CursorProbeProps;
+
+        #[derive(Default)]
+        struct CursorProbe;
+
+        impl Component for CursorProbe {
+            type Props<'a> = CursorProbeProps;
+
+            fn new(_props: &Self::Props<'_>) -> Self {
+                Self
+            }
+
+            fn update(
+                &mut self,
+                _props: &mut Self::Props<'_>,
+                _hooks: Hooks,
+                updater: &mut ComponentUpdater,
+            ) {
+                updater.set_layout_style(
+                    LayoutStyle {
+                        flex_grow: 1.0,
+                        ..Default::default()
+                    }
+                    .into(),
+                );
+            }
+
+            fn draw(&mut self, drawer: &mut ComponentDrawer<'_>) {
+                // request the cursor 2 cells right of this component's top-left
+                drawer.set_cursor(2, 0, CursorShape::Bar);
+            }
+        }
+
+        // padding offsets the probe to (3, 1); set_cursor(2, 0) -> absolute (5, 1)
+        let canvas = render(
+            element! {
+                View(padding_left: 3u16, padding_top: 1u16, width: 10u16, height: 3u16) {
+                    CursorProbe
+                }
+            },
+            None,
+        );
+        assert_eq!(
+            canvas.cursor(),
+            Some(Cursor {
+                x: 5,
+                y: 1,
+                shape: CursorShape::Bar,
+            })
+        );
     }
 
     #[apply(test!)]

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -1,4 +1,7 @@
-use crate::{canvas::Canvas, element::Output};
+use crate::{
+    canvas::{Canvas, Cursor, CursorShape},
+    element::Output,
+};
 use crossterm::{
     cursor,
     event::{self, Event, EventStream},
@@ -123,6 +126,10 @@ trait TerminalImpl: Write + Send {
     fn is_raw_mode_enabled(&self) -> bool;
     fn clear_canvas(&mut self) -> io::Result<()>;
     fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()>;
+    /// Places (or hides) the real terminal cursor after the canvas is written.
+    fn write_cursor(&mut self, _cursor: Option<&Cursor>) -> io::Result<()> {
+        Ok(())
+    }
     fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>>;
     fn dest(&mut self) -> &mut dyn Write;
     fn alt(&mut self) -> &mut dyn Write;
@@ -221,6 +228,27 @@ impl TerminalImpl for StdTerminal<'_> {
         }
 
         clear_canvas_inline(&mut *self.dest, self.prev_canvas_height)
+    }
+
+    fn write_cursor(&mut self, cursor: Option<&Cursor>) -> io::Result<()> {
+        match cursor {
+            Some(c) => {
+                let style = match c.shape {
+                    CursorShape::Default => cursor::SetCursorStyle::DefaultUserShape,
+                    CursorShape::Block => cursor::SetCursorStyle::SteadyBlock,
+                    CursorShape::Bar => cursor::SetCursorStyle::SteadyBar,
+                    CursorShape::Underline => cursor::SetCursorStyle::SteadyUnderScore,
+                };
+                self.dest
+                    .queue(cursor::MoveTo(c.x, self.prev_canvas_top_row + c.y))?
+                    .queue(style)?
+                    .queue(cursor::Show)?;
+            }
+            None => {
+                self.dest.queue(cursor::Hide)?;
+            }
+        }
+        Ok(())
     }
 
     fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()> {
@@ -629,6 +657,10 @@ impl<'a> Terminal<'a> {
 
     pub fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()> {
         self.inner.write_canvas(prev, canvas)
+    }
+
+    pub fn write_cursor(&mut self, cursor: Option<&Cursor>) -> io::Result<()> {
+        self.inner.write_cursor(cursor)
     }
 
     pub fn received_ctrl_c(&self) -> bool {


### PR DESCRIPTION
Opening this as a **draft** to give #195 something concrete to react to — the API shape is open for discussion, happy to reshape it however you prefer.

## Why

Today the real terminal cursor is `cursor::Hide`'d for the whole app lifetime, and `ComponentDrawer` / `CanvasSubviewMut` expose no cursor method, so `TextInput` (and anything embedding a terminal) can only synthesize a block by reverse-videoing a cell — no bar/underline shape, no real cursor. See #195.

## What

An opt-in real terminal cursor that a low-level component can request during drawing.

## How

- `ComponentDrawer::set_cursor(x, y, shape)` records a `Cursor { x, y, shape }` (in absolute canvas coordinates) on the `Canvas`. The most recently drawn (topmost) requester wins.
- New `Cursor` / `CursorShape { Default, Block, Bar, Underline }` types; `Canvas::{cursor, set_cursor}`.
- A `TerminalImpl::write_cursor` (default no-op) that `StdTerminal` implements: after `write_canvas`, emit `MoveTo` + `SetCursorStyle` + `Show` when a cursor is requested, or `Hide` when none is. Wired into `terminal_render_loop`.
- Because `Cursor` is part of `Canvas` equality, a cursor move naturally participates in the render loop's redraw check.
- Test: `test_component_cursor` renders a low-level component that calls `set_cursor` and asserts the resulting absolute `Canvas::cursor()`.

## Rationale / open questions

- The cursor lives on the `Canvas` (already handed to `write_canvas`), so no extra plumbing through the render tree.
- `set_cursor` takes coordinates + shape; glad to adjust the signature (e.g. an explicit visibility flag, or blink variants).
- Emission is wired into the interactive `terminal_render_loop`; the row offset uses `prev_canvas_top_row`. Kept minimal on purpose — happy to extend based on the direction you'd like to take #195.

Refs #195
