### PR TITLE
fix: propagate terminal input errors

### DIFF
--- a/packages/iocraft/CHANGELOG.md
+++ b/packages/iocraft/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- propagate terminal input errors from interactive render loops
+
 ## [0.8.4](https://github.com/ccbrown/iocraft/compare/iocraft-v0.8.3...iocraft-v0.8.4) - 2026-07-13
 
 ### Added

--- a/packages/iocraft/CHANGELOG.md
+++ b/packages/iocraft/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- propagate terminal input errors from interactive render loops
-
 ## [0.8.4](https://github.com/ccbrown/iocraft/compare/iocraft-v0.8.3...iocraft-v0.8.4) - 2026-07-13
 
 ### Added

--- a/packages/iocraft/src/render.rs
+++ b/packages/iocraft/src/render.rs
@@ -14,7 +14,7 @@ use core::{
     task::{self, Poll},
 };
 use futures::{
-    future::{select, FutureExt, LocalBoxFuture},
+    future::{select, Either, FutureExt, LocalBoxFuture},
     stream::{Stream, StreamExt},
 };
 use std::io;
@@ -493,7 +493,11 @@ impl<'a> Tree<'a> {
             if self.system_context.should_exit() || term.received_ctrl_c() {
                 break;
             }
-            select(self.root_component.wait().boxed(), term.wait().boxed()).await;
+            if let Either::Right((result, _)) =
+                select(self.root_component.wait().boxed(), term.wait().boxed()).await
+            {
+                result?;
+            }
             if term.received_ctrl_c() {
                 break;
             }
@@ -623,6 +627,18 @@ mod tests {
     async fn test_terminal_render_loop_send() {
         let (term, _output) = Terminal::mock(MockTerminalConfig::default());
         await_send_future(terminal_render_loop(&mut element!(MyComponent), term)).await;
+    }
+
+    #[apply(test!)]
+    async fn test_terminal_render_loop_propagates_input_errors() {
+        let term = Terminal::mock_with_event_error(io::Error::other("input failed"));
+
+        let error = terminal_render_loop(&mut element!(View), term)
+            .await
+            .expect_err("terminal input errors should stop the render loop");
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "input failed");
     }
 
     #[component]

--- a/packages/iocraft/src/terminal.rs
+++ b/packages/iocraft/src/terminal.rs
@@ -123,7 +123,7 @@ trait TerminalImpl: Write + Send {
     fn is_raw_mode_enabled(&self) -> bool;
     fn clear_canvas(&mut self) -> io::Result<()>;
     fn write_canvas(&mut self, prev: Option<&Canvas>, canvas: &Canvas) -> io::Result<()>;
-    fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>>;
+    fn event_stream(&mut self) -> io::Result<BoxStream<'static, io::Result<TerminalEvent>>>;
     fn dest(&mut self) -> &mut dyn Write;
     fn alt(&mut self) -> &mut dyn Write;
 }
@@ -354,7 +354,7 @@ impl TerminalImpl for StdTerminal<'_> {
         Ok(())
     }
 
-    fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>> {
+    fn event_stream(&mut self) -> io::Result<BoxStream<'static, io::Result<TerminalEvent>>> {
         if !self.input_is_terminal {
             return Ok(stream::pending().boxed());
         }
@@ -364,21 +364,25 @@ impl TerminalImpl for StdTerminal<'_> {
         Ok(EventStream::new()
             .filter_map(|event| async move {
                 match event {
-                    Ok(Event::Key(event)) => Some(TerminalEvent::Key(KeyEvent {
+                    Ok(Event::Key(event)) => Some(Ok(TerminalEvent::Key(KeyEvent {
                         code: event.code,
                         modifiers: event.modifiers,
                         kind: event.kind,
-                    })),
+                    }))),
                     Ok(Event::Mouse(event)) => {
-                        Some(TerminalEvent::FullscreenMouse(FullscreenMouseEvent {
+                        Some(Ok(TerminalEvent::FullscreenMouse(FullscreenMouseEvent {
                             modifiers: event.modifiers,
                             column: event.column,
                             row: event.row,
                             kind: event.kind,
-                        }))
+                        })))
                     }
-                    Ok(Event::Resize(width, height)) => Some(TerminalEvent::Resize(width, height)),
-                    _ => None,
+                    Ok(Event::Resize(width, height)) => {
+                        Some(Ok(TerminalEvent::Resize(width, height)))
+                    }
+                    // Ignore crossterm events that iocraft does not expose.
+                    Ok(_) => None,
+                    Err(error) => Some(Err(error)),
                 }
             })
             .boxed())
@@ -552,10 +556,10 @@ impl TerminalImpl for MockTerminal {
         Ok(())
     }
 
-    fn event_stream(&mut self) -> io::Result<BoxStream<'static, TerminalEvent>> {
+    fn event_stream(&mut self) -> io::Result<BoxStream<'static, io::Result<TerminalEvent>>> {
         let mut events = stream::pending().boxed();
         mem::swap(&mut events, &mut self.config.events);
-        Ok(events.chain(stream::pending()).boxed())
+        Ok(events.map(Ok).chain(stream::pending()).boxed())
     }
 
     fn dest(&mut self) -> &mut dyn Write {
@@ -570,7 +574,7 @@ impl TerminalImpl for MockTerminal {
 pub(crate) struct Terminal<'a> {
     inner: Box<dyn TerminalImpl + 'a>,
     output: Output,
-    event_stream: Option<BoxStream<'static, TerminalEvent>>,
+    event_stream: Option<BoxStream<'static, io::Result<TerminalEvent>>>,
     subscribers: Vec<Weak<Mutex<TerminalEventsInner>>>,
     received_ctrl_c: bool,
     ignore_ctrl_c: bool,
@@ -666,10 +670,11 @@ impl<'a> Terminal<'a> {
         f(t.inner)
     }
 
-    pub async fn wait(&mut self) {
+    pub async fn wait(&mut self) -> io::Result<()> {
         match &mut self.event_stream {
             Some(event_stream) => {
                 while let Some(event) = event_stream.next().await {
+                    let event = event?;
                     if !self.ignore_ctrl_c {
                         if let TerminalEvent::Key(KeyEvent {
                             code: KeyCode::Char('c'),
@@ -680,7 +685,7 @@ impl<'a> Terminal<'a> {
                             self.received_ctrl_c = true;
                         }
                         if self.received_ctrl_c {
-                            return;
+                            return Ok(());
                         }
                     }
                     self.subscribers.retain(|subscriber| {
@@ -696,6 +701,10 @@ impl<'a> Terminal<'a> {
                         }
                     });
                 }
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "terminal event stream ended",
+                ))
             }
             None => pending().await,
         }
@@ -728,6 +737,13 @@ impl Terminal<'static> {
             },
             output_stream,
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mock_with_event_error(error: io::Error) -> Self {
+        let (mut terminal, _output) = Self::mock(MockTerminalConfig::default());
+        terminal.event_stream = Some(stream::once(async move { Err(error) }).boxed());
+        terminal
     }
 }
 


### PR DESCRIPTION
## Summary

- Preserve errors emitted by the crossterm `EventStream` when converting terminal events.
- Return input errors and unexpected stream termination from interactive render loops.
- Add a regression test verifying that terminal input errors stop interactive render loops and are returned to callers.
- Document the fix in the changelog.

## Motivation

The crossterm event stream emits `io::Result<Event>`, but iocraft filtered errors out together with unsupported event variants. Applications therefore could not respond when terminal input failed, and persistent failures could continue to be polled instead of stopping the render loop.

The public event API remains unchanged. Errors flow through the internal terminal stream and are returned by `render_loop`, whose result is already an `io::Result`.

This was observed in cachix/devenv#3013, where closing a Zed terminal pane left devenv up consuming 100%+ CPU. Pending crossterm-rs/crossterm#1070 and crossterm-rs/crossterm#1067 would expose that terminal disconnection through EventStream.

---

Assisted by Codex:gpt-5.6-sol.