### PR TITLE
fix: don't consider empty rows equal to non-existent rows

### DIFF
--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -248,12 +248,12 @@ impl Canvas {
         }
     }
 
-    fn row(&self, y: usize) -> &[CanvasCell] {
+    fn row(&self, y: usize) -> Option<&[CanvasCell]> {
         let Some(row) = self.cells.get(y) else {
-            return &[];
+            return None;
         };
         let last_non_empty = row.iter().rposition(|cell| !cell.is_empty());
-        &row[..last_non_empty.map_or(0, |i| i + 1)]
+        Some(&row[..last_non_empty.map_or(0, |i| i + 1)])
     }
 
     pub(crate) fn row_eq(&self, other: &Self, y: usize) -> bool {
@@ -268,7 +268,7 @@ impl Canvas {
     /// so consecutive calls (or any subsequent writer use) start from a clean
     /// state.
     fn write_row_impl<W: Write>(&self, y: usize, mut w: W, ansi: bool) -> io::Result<()> {
-        let row = self.row(y);
+        let row = self.row(y).unwrap_or(&[]);
 
         let mut background_color = None;
         let mut text_style = CanvasTextStyle::default();

--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -249,9 +249,7 @@ impl Canvas {
     }
 
     fn row(&self, y: usize) -> Option<&[CanvasCell]> {
-        let Some(row) = self.cells.get(y) else {
-            return None;
-        };
+        let row = self.cells.get(y)?;
         let last_non_empty = row.iter().rposition(|cell| !cell.is_empty());
         Some(&row[..last_non_empty.map_or(0, |i| i + 1)])
     }

--- a/packages/iocraft/src/canvas.rs
+++ b/packages/iocraft/src/canvas.rs
@@ -1100,7 +1100,7 @@ line two
         let b = Canvas::new(10, 2);
 
         // row 1 is out of bounds for a, but exists (empty) in b
-        assert!(a.row_eq(&b, 1));
+        assert!(!a.row_eq(&b, 1));
     }
 
     #[test]


### PR DESCRIPTION
## What It Does

`row_eq` currently returns `true` if you give it a row that is empty in one canvas but doesn't exist in the other.

This seems to have been intentional as there was a test that asserted this behavior. However, it's surprising and seems to lead to the bug found in https://github.com/ccbrown/iocraft/pull/221. Changing this behavior resolves that issue and shouldn't have any adverse effects that I can think of.

## Related Issues

- https://github.com/ccbrown/iocraft/pull/221
